### PR TITLE
Removed all async code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,24 +3,20 @@ name = "rust_socketio"
 version = "0.1.1"
 authors = ["Bastian Kersting <bastian@cmbt.de>"]
 edition = "2018"
-description = "An implementation of a socketio client written in async rust."
+description = "An implementation of a socketio client written in rust."
 readme = "README.md"
 repository = "https://github.com/1c3t3a/rust-socketio"
 keywords = ["socketio", "engineio", "network"]
-categories = ["asynchronous", "network-programming", "web-programming", "web-programming::websocket"]
+categories = ["network-programming", "web-programming", "web-programming::websocket"]
 license = "MIT"
 
 [dependencies]
 base64 = "0.13.0"
 rand = "0.8.1"
 crossbeam-utils = "0.8.1"
-reqwest = "0.11.0"
-tokio = { version = "1.0", features = ["full"] }
+reqwest = { version = "0.11.0", features = ["blocking"] }
 adler32 = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.4.2"
 if_chain = "1.0.1"
-
-[dev-dependencies]
-actix-rt = "2.0.0-beta.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "An implementation of a socketio client written in rust."
 readme = "README.md"
 repository = "https://github.com/1c3t3a/rust-socketio"
-keywords = ["socketio", "engineio", "network"]
+keywords = ["socketio", "engineio", "network", "socket.io", "client"]
 categories = ["network-programming", "web-programming", "web-programming::websocket"]
 license = "MIT"
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: build test clippy format
+.PHONY: build test-fast test-all clippy format
 
 build: 
 	@cargo build --verbose
 
-test:
-	@cargo test --verbose --package rust_socketio --lib -- socketio::packet::test 
+test-fast:
+	@cargo test --verbose --package rust_socketio --lib -- socketio::packet::test engineio::packet::test
+
+test-all:
+	@cargo test --verbose 
 
 clippy:
 	@cargo clippy --verbose
@@ -12,7 +15,12 @@ clippy:
 format:
 	@cargo fmt --all -- --check
 
-checks: build test clippy format
+checks: build test-fast clippy format
+	@echo "### Don't forget to add untracked files! ###"
+	@git status
+	@echo "### Awesome work! 😍 ###"""
+
+pipeline: build test-all clippy format
 	@echo "### Don't forget to add untracked files! ###"
 	@git status
 	@echo "### Awesome work! 😍 ###"""

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Rust-socketio-client
 
-An asynchronous implementation of a socket.io client written in the Rust programming language. This implementation currently supports revision 5 of the socket.io protocol and therefore revision 4 of the engine.io protocol.
+An implementation of a socket.io client written in the Rust programming language. This implementation currently supports revision 5 of the socket.io protocol and therefore revision 4 of the engine.io protocol.
 
 ## Example usage
 
@@ -12,24 +12,23 @@ use rust_socketio::Socket;
 use serde_json::json;
 use tokio::time::sleep;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let mut socket = Socket::new(String::from("http://localhost:80"), Some("/admin"));
 
     // callback for the "foo" event
     socket.on("foo", |message| println!("{}", message)).unwrap();
 
     // connect to the server
-    socket.connect().await.expect("Connection failed");
+    socket.connect().expect("Connection failed");
 
     // emit to the "foo" event
     let payload = json!({"token": 123});
-    socket.emit("foo", payload.to_string()).await.expect("Server unreachable");
+    socket.emit("foo", payload.to_string()).expect("Server unreachable");
 
     // emit with an ack
-    let ack = socket.emit_with_ack("foo", payload.to_string(), Duration::from_secs(2)).await.unwrap();
+    let ack = socket.emit_with_ack("foo", payload.to_string(), Duration::from_secs(2)).unwrap();
 
-    sleep(Duration::from_secs(2)).await;
+    sleep(Duration::from_secs(2));
 
     // check if ack is present and read the data
     if ack.read().expect("Server panicked anyway").acked {
@@ -44,7 +43,7 @@ Documentation of this crate can be found up on [docs.rs](https://docs.rs/rust_so
 
 ## Current features
 
-This is the first released version of the client, so it still lacks some features that the normal client would provide. First of all the underlying engine.io protocol still uses long-polling instead of websockets. This will be resolved as soon as both the reqwest libary as well as tungstenite-websockets will bump their tokio version to 1.0.0. At the moment only reqwest is used for async long polling. In general the full engine-io protocol is implemented and most of the features concerning the 'normal' socket.io protocol work as well.
+This is the first released version of the client, so it still lacks some features that the normal client would provide. First of all the underlying engine.io protocol still uses long-polling instead of websockets. This will be resolved as soon as both the reqwest libary as well as tungstenite-websockets will bump their tokio version to 1.0.0. At the moment only reqwest is used for long polling. In general the full engine-io protocol is implemented and most of the features concerning the 'normal' socket.io protocol work as well.
 
 Here's an overview of possible use-cases:
 
@@ -60,7 +59,7 @@ Here's an overview of possible use-cases:
 
 What's currently missing is the emitting of binary data - I aim to implement this as soon as possible.
 
-The whole crate is written in asynchronous rust and it's necessary to use [tokio](https://docs.rs/tokio/1.0.1/tokio/), or other executors with this libary to resolve the futures.
+The whole crate is written in rust and it's necessary to use [tokio](https://docs.rs/tokio/1.0.1/tokio/), or other executors with this libary to resolve the futures.
 
 ## Content of this repository
 

--- a/example/engine-io.js
+++ b/example/engine-io.js
@@ -3,7 +3,7 @@
  * It might be a good idea to use this in an automated test.
  */
 const engine = require('engine.io');
-const server = engine.listen(4200);
+const server = engine.listen(4201);
 
 console.log("Started")
 server.on('connection', socket => {
@@ -11,6 +11,9 @@ server.on('connection', socket => {
 
     socket.on('message', message => {
         console.log(message.toString());
+        if (message == "PlsEnd") {
+            socket.close();
+        }
     });
 
     socket.on('ping', () => {

--- a/example/engine-io.js
+++ b/example/engine-io.js
@@ -1,8 +1,8 @@
 /**
  * This is an example server, used to test the current code.
- * It might be a good idea to use this in an automated test.
  */
 const engine = require('engine.io');
+// the engine.io client runs on port 4201
 const server = engine.listen(4201);
 
 console.log("Started")
@@ -11,7 +11,7 @@ server.on('connection', socket => {
 
     socket.on('message', message => {
         console.log(message.toString());
-        if (message == "PlsEnd") {
+        if (message == "CLOSE") {
             socket.close();
         }
     });

--- a/example/example_engineio.rs
+++ b/example/example_engineio.rs
@@ -1,7 +1,4 @@
-use tokio::time::sleep;
-
-#[tokio::main]
-async fn main() {
+fn main() {
     let mut socket = EngineSocket::new(true);
 
     socket.on_open(|_| {
@@ -22,27 +19,26 @@ async fn main() {
 
     socket
         .bind(String::from("http://localhost:4200"))
-        .await
         .unwrap();
 
     socket.emit(Packet::new(
             PacketId::Message,
             "Hello World".to_string().into_bytes(),
-    )).await.unwrap();
+    )).unwrap();
 
     socket.emit(Packet::new(
             PacketId::Message,
             "Hello World2".to_string().into_bytes(),
-    )).await.unwrap();
+    )).unwrap();
 
-    socket.emit(Packet::new(PacketId::Pong, Vec::new())).await.unwrap();
+    socket.emit(Packet::new(PacketId::Pong, Vec::new())).unwrap();
 
-    socket.emit(Packet::new(PacketId::Ping, Vec::new())).await.unwrap();
+    socket.emit(Packet::new(PacketId::Ping, Vec::new())).unwrap();
 
-    sleep(Duration::from_secs(26)).await;
+    sleep(Duration::from_secs(26));
 
     socket.emit(Packet::new(
         PacketId::Message,
         "Hello World3".to_string().into_bytes(),
-    )).await.unwrap();
+    )).unwrap();
 }

--- a/example/example_engineio.rs
+++ b/example/example_engineio.rs
@@ -23,12 +23,12 @@ fn main() {
 
     socket.emit(Packet::new(
             PacketId::Message,
-            "Hello World".to_string().into_bytes(),
+            "Hello World".to_owned().into_bytes(),
     )).unwrap();
 
     socket.emit(Packet::new(
             PacketId::Message,
-            "Hello World2".to_string().into_bytes(),
+            "Hello World2".to_owned().into_bytes(),
     )).unwrap();
 
     socket.emit(Packet::new(PacketId::Pong, Vec::new())).unwrap();
@@ -39,6 +39,6 @@ fn main() {
 
     socket.emit(Packet::new(
         PacketId::Message,
-        "Hello World3".to_string().into_bytes(),
+        "Hello World3".to_owned().into_bytes(),
     )).unwrap();
 }

--- a/example/socket-io.js
+++ b/example/socket-io.js
@@ -14,4 +14,5 @@ io.on('connection', client => {
       });
     client.emit("test", "Hello Wld");
 });
+// the socket.io client runs on port 4201
 server.listen(4200);

--- a/src/engineio/packet.rs
+++ b/src/engineio/packet.rs
@@ -29,15 +29,15 @@ const SEPERATOR: char = '\x1e';
 
 /// Converts a byte into the corresponding packet id.
 #[inline]
-fn u8_to_packet_id(b: u8) -> Result<PacketId, Error> {
-    match b {
-        48_u8 => Ok(PacketId::Open),
-        49_u8 => Ok(PacketId::Close),
-        50_u8 => Ok(PacketId::Ping),
-        51_u8 => Ok(PacketId::Pong),
-        52_u8 => Ok(PacketId::Message),
-        53_u8 => Ok(PacketId::Upgrade),
-        54_u8 => Ok(PacketId::Noop),
+const fn u8_to_packet_id(b: u8) -> Result<PacketId, Error> {
+    match b as char {
+        '0' => Ok(PacketId::Open),
+        '1' => Ok(PacketId::Close),
+        '2' => Ok(PacketId::Ping),
+        '3' => Ok(PacketId::Pong),
+        '4' => Ok(PacketId::Message),
+        '5' => Ok(PacketId::Upgrade),
+        '6' => Ok(PacketId::Noop),
         _ => Err(Error::InvalidPacketId(b)),
     }
 }
@@ -57,13 +57,13 @@ impl Packet {
             return Err(Error::EmptyPacket);
         }
 
-        let is_base64 = bytes[0] == b'b';
+        let is_base64 = *bytes.get(0).ok_or(Error::IncompletePacket)? == b'b';
 
         // only 'messages' packets could be encoded
         let packet_id = if is_base64 {
             PacketId::Message
         } else {
-            u8_to_packet_id(bytes[0])?
+            u8_to_packet_id(*bytes.get(0).ok_or(Error::IncompletePacket)?)?
         };
 
         if bytes.len() == 1 && packet_id == PacketId::Message {

--- a/src/engineio/packet.rs
+++ b/src/engineio/packet.rs
@@ -194,7 +194,7 @@ mod tests {
         assert_eq!(packets[1].packet_id, PacketId::Message);
         assert_eq!(packets[1].data, ("HelloWorld".to_string().into_bytes()));
 
-        let data = "bSGVsbG8=\x1ebSGVsbG9Xb3JsZA==".to_string().into_bytes();
+        let data = "4Hello\x1e4HelloWorld".to_string().into_bytes();
         assert_eq!(encode_payload(packets), data);
     }
 }

--- a/src/engineio/packet.rs
+++ b/src/engineio/packet.rs
@@ -30,14 +30,14 @@ const SEPERATOR: char = '\x1e';
 /// Converts a byte into the corresponding packet id.
 #[inline]
 fn u8_to_packet_id(b: u8) -> Result<PacketId, Error> {
-    match b as char {
-        '0' => Ok(PacketId::Open),
-        '1' => Ok(PacketId::Close),
-        '2' => Ok(PacketId::Ping),
-        '3' => Ok(PacketId::Pong),
-        '4' => Ok(PacketId::Message),
-        '5' => Ok(PacketId::Upgrade),
-        '6' => Ok(PacketId::Noop),
+    match b {
+        48_u8 => Ok(PacketId::Open),
+        49_u8 => Ok(PacketId::Close),
+        50_u8 => Ok(PacketId::Ping),
+        51_u8 => Ok(PacketId::Pong),
+        52_u8 => Ok(PacketId::Message),
+        53_u8 => Ok(PacketId::Upgrade),
+        54_u8 => Ok(PacketId::Noop),
         _ => Err(Error::InvalidPacketId(b)),
     }
 }

--- a/src/engineio/packet.rs
+++ b/src/engineio/packet.rs
@@ -147,40 +147,40 @@ mod tests {
 
     #[test]
     fn test_is_reflexive() {
-        let data = "1Hello World".to_string().into_bytes();
+        let data = "1Hello World".to_owned().into_bytes();
         let packet = Packet::decode_packet(data).unwrap();
 
         assert_eq!(packet.packet_id, PacketId::Close);
-        assert_eq!(packet.data, "Hello World".to_string().into_bytes());
+        assert_eq!(packet.data, "Hello World".to_owned().into_bytes());
 
-        let data: Vec<u8> = "1Hello World".to_string().into_bytes();
+        let data: Vec<u8> = "1Hello World".to_owned().into_bytes();
         assert_eq!(Packet::encode_packet(packet), data);
     }
 
     #[test]
     fn test_binary_packet() {
         // SGVsbG8= is the encoded string for 'Hello'
-        let data = "bSGVsbG8=".to_string().into_bytes();
+        let data = "bSGVsbG8=".to_owned().into_bytes();
         let packet = Packet::decode_packet(data).unwrap();
 
         assert_eq!(packet.packet_id, PacketId::Message);
-        assert_eq!(packet.data, "Hello".to_string().into_bytes());
+        assert_eq!(packet.data, "Hello".to_owned().into_bytes());
 
-        let data = "bSGVsbG8=".to_string().into_bytes();
+        let data = "bSGVsbG8=".to_owned().into_bytes();
         assert_eq!(Packet::encode_base64(packet), data);
     }
 
     #[test]
     fn test_decode_payload() {
-        let data = "1Hello\x1e1HelloWorld".to_string().into_bytes();
+        let data = "1Hello\x1e1HelloWorld".to_owned().into_bytes();
         let packets = decode_payload(data).unwrap();
 
         assert_eq!(packets[0].packet_id, PacketId::Close);
-        assert_eq!(packets[0].data, ("Hello".to_string().into_bytes()));
+        assert_eq!(packets[0].data, ("Hello".to_owned().into_bytes()));
         assert_eq!(packets[1].packet_id, PacketId::Close);
-        assert_eq!(packets[1].data, ("HelloWorld".to_string().into_bytes()));
+        assert_eq!(packets[1].data, ("HelloWorld".to_owned().into_bytes()));
 
-        let data = "1Hello\x1e1HelloWorld".to_string().into_bytes();
+        let data = "1Hello\x1e1HelloWorld".to_owned().into_bytes();
         assert_eq!(encode_payload(packets), data);
     }
 
@@ -190,11 +190,11 @@ mod tests {
         let packets = decode_payload(data).unwrap();
 
         assert_eq!(packets[0].packet_id, PacketId::Message);
-        assert_eq!(packets[0].data, ("Hello".to_string().into_bytes()));
+        assert_eq!(packets[0].data, ("Hello".to_owned().into_bytes()));
         assert_eq!(packets[1].packet_id, PacketId::Message);
-        assert_eq!(packets[1].data, ("HelloWorld".to_string().into_bytes()));
+        assert_eq!(packets[1].data, ("HelloWorld".to_owned().into_bytes()));
 
-        let data = "4Hello\x1e4HelloWorld".to_string().into_bytes();
+        let data = "4Hello\x1e4HelloWorld".to_owned().into_bytes();
         assert_eq!(encode_payload(packets), data);
     }
 }

--- a/src/engineio/socket.rs
+++ b/src/engineio/socket.rs
@@ -35,9 +35,9 @@ impl EngineSocket {
         thread::spawn(move || {
             let s = cl.read().unwrap().clone();
             // this tries to restart a poll cycle whenever a 'normal' error
-            // occurs, it just panics on network errors in case the poll cycle
-            // returened Ok, the server received a close frame anyway, so it's
-            // safe to terminate
+            // occurs, it just panics on network errors. in case the poll cycle
+            // returened Result::Ok, the server received a close frame anyway,
+            // so it's safe to terminate.
             loop {
                 match s.poll_cycle() {
                     Ok(_) => break,

--- a/src/engineio/transport.rs
+++ b/src/engineio/transport.rs
@@ -1,7 +1,7 @@
 use crate::engineio::packet::{decode_payload, encode_payload, Packet, PacketId};
 use crate::error::Error;
 use adler32::adler32;
-use reqwest::{Client, Url};
+use reqwest::{blocking::Client, Url};
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 use std::{fmt::Debug, sync::atomic::Ordering};
@@ -71,60 +71,65 @@ impl TransportClient {
     }
 
     /// Registers an on_open callback.
-    pub fn set_on_open<F>(&mut self, function: F)
+    pub fn set_on_open<F>(&mut self, function: F) -> Result<(), Error>
     where
         F: Fn(()) + 'static + Sync + Send,
     {
-        let mut on_open = self.on_open.write().unwrap();
+        let mut on_open = self.on_open.write()?;
         *on_open = Some(Box::new(function));
         drop(on_open);
+        Ok(())
     }
 
     /// Registers an on_error callback.
-    pub fn set_on_error<F>(&mut self, function: F)
+    pub fn set_on_error<F>(&mut self, function: F) -> Result<(), Error>
     where
         F: Fn(String) + 'static + Sync + Send,
     {
-        let mut on_error = self.on_error.write().unwrap();
+        let mut on_error = self.on_error.write()?;
         *on_error = Some(Box::new(function));
         drop(on_error);
+        Ok(())
     }
 
     /// Registers an on_packet callback.
-    pub fn set_on_packet<F>(&mut self, function: F)
+    pub fn set_on_packet<F>(&mut self, function: F) -> Result<(), Error>
     where
         F: Fn(Packet) + 'static + Sync + Send,
     {
-        let mut on_packet = self.on_packet.write().unwrap();
+        let mut on_packet = self.on_packet.write()?;
         *on_packet = Some(Box::new(function));
         drop(on_packet);
+        Ok(())
     }
 
     /// Registers an on_data callback.
-    pub fn set_on_data<F>(&mut self, function: F)
+    pub fn set_on_data<F>(&mut self, function: F) -> Result<(), Error>
     where
         F: Fn(Vec<u8>) + 'static + Sync + Send,
     {
-        let mut on_data = self.on_data.write().unwrap();
+        let mut on_data = self.on_data.write()?;
         *on_data = Some(Box::new(function));
         drop(on_data);
+        Ok(())
     }
 
     /// Registers an on_close callback.
-    pub fn set_on_close<F>(&mut self, function: F)
+    pub fn set_on_close<F>(&mut self, function: F) -> Result<(), Error>
     where
         F: Fn(()) + 'static + Sync + Send,
     {
-        let mut on_close = self.on_close.write().unwrap();
+        let mut on_close = self.on_close.write()?;
         *on_close = Some(Box::new(function));
         drop(on_close);
+        Ok(())
     }
 
     /// Opens the connection to a certain server. This includes an opening GET
     /// request to the server. The server passes back the handshake data in the
     /// response. Afterwards a first Pong packet is sent to the server to
     /// trigger the Ping-cycle.
-    pub async fn open(&mut self, address: String) -> Result<(), Error> {
+    pub fn open<T: Into<String> + Clone>(&mut self, address: T) -> Result<(), Error> {
         // TODO: Check if Relaxed is appropiate -> change all occurences if not
         if self.connected.load(Ordering::Relaxed) {
             return Ok(());
@@ -135,56 +140,49 @@ impl TransportClient {
 
         match &mut self.transport {
             TransportType::Polling(client) => {
-                if let Ok(full_address) = Url::parse(&(address.clone() + &query_path)[..]) {
-                    self.host_address = Arc::new(Mutex::new(Some(address)));
+                if let Ok(full_address) = Url::parse(&(address.clone().into() + &query_path)) {
+                    self.host_address = Arc::new(Mutex::new(Some(address.into())));
 
-                    let response = client
-                        .lock()
-                        .unwrap()
-                        .get(full_address)
-                        .send()
-                        .await?
-                        .text()
-                        .await?;
+                    let response = client.lock()?.get(full_address).send()?.text()?;
 
                     // the response contains the handshake data
                     if let Ok(conn_data) = serde_json::from_str(&response[1..]) {
                         self.connection_data = Arc::new(conn_data);
 
                         // call the on_open callback
-                        let function = self.on_open.read().unwrap();
+                        let function = self.on_open.read()?;
                         if let Some(function) = function.as_ref() {
                             spawn_scoped!(function(()));
                         }
                         drop(function);
 
                         // set the last ping to now and set the connected state
-                        *self.last_ping.lock().unwrap() = Instant::now();
+                        *self.last_ping.lock()? = Instant::now();
                         *Arc::get_mut(&mut self.connected).unwrap() = AtomicBool::from(true);
 
                         // emit a pong packet to keep trigger the ping cycle on the server
-                        self.emit(Packet::new(PacketId::Pong, Vec::new())).await?;
+                        self.emit(Packet::new(PacketId::Pong, Vec::new()))?;
 
                         return Ok(());
                     }
 
                     let error = Error::HandshakeError(response);
-                    self.call_error_callback(format!("{}", error));
+                    self.call_error_callback(format!("{}", error))?;
                     return Err(error);
                 }
 
-                let error = Error::InvalidUrl(address);
-                self.call_error_callback(format!("{}", error));
-                return Err(error);
+                let error = Error::InvalidUrl(address.into());
+                self.call_error_callback(format!("{}", error))?;
+                Err(error)
             }
         }
     }
 
     /// Sends a packet to the server
-    pub async fn emit(&self, packet: Packet) -> Result<(), Error> {
+    pub fn emit(&self, packet: Packet) -> Result<(), Error> {
         if !self.connected.load(Ordering::Relaxed) {
             let error = Error::ActionBeforeOpen;
-            self.call_error_callback(format!("{}", error));
+            self.call_error_callback(format!("{}", error))?;
             return Err(error);
         }
 
@@ -193,26 +191,20 @@ impl TransportClient {
                 let query_path = self.get_query_path();
 
                 // build the target address
-                let host = self.host_address.lock().unwrap().clone();
+                let host = self.host_address.lock()?.clone();
                 let address =
                     Url::parse(&(host.as_ref().unwrap().to_owned() + &query_path)[..]).unwrap();
                 drop(host);
 
                 // send a post request with the encoded payload as body
                 let data = encode_payload(vec![packet]);
-                let client = client.lock().unwrap().clone();
-                let status = client
-                    .post(address)
-                    .body(data)
-                    .send()
-                    .await?
-                    .status()
-                    .as_u16();
+                let client = client.lock()?.clone();
+                let status = client.post(address).body(data).send()?.status().as_u16();
                 drop(client);
 
                 if status != 200 {
                     let error = Error::HttpError(status);
-                    self.call_error_callback(format!("{}", error));
+                    self.call_error_callback(format!("{}", error))?;
                     return Err(error);
                 }
 
@@ -224,16 +216,16 @@ impl TransportClient {
     /// Performs the server long polling procedure as long as the client is
     /// connected. This should run separately at all time to ensure proper
     /// response handling from the server.
-    pub async fn poll_cycle(&self) -> Result<(), Error> {
+    pub fn poll_cycle(&self) -> Result<(), Error> {
         if !self.connected.load(Ordering::Relaxed) {
             let error = Error::ActionBeforeOpen;
-            self.call_error_callback(format!("{}", error));
+            self.call_error_callback(format!("{}", error))?;
             return Err(error);
         }
         let client = Client::new();
 
         // as we don't have a mut self, the last_ping needs to be safed for later
-        let mut last_ping = *self.last_ping.clone().lock().unwrap();
+        let mut last_ping = *self.last_ping.clone().lock()?;
         // the time after we assume the server to be timed out
         let server_timeout = Duration::from_millis(
             Arc::as_ref(&self.connection_data)
@@ -253,18 +245,18 @@ impl TransportClient {
                 TransportType::Polling(_) => {
                     let query_path = self.get_query_path();
 
-                    let host = self.host_address.lock().unwrap().clone();
+                    let host = self.host_address.lock()?.clone();
                     let address =
                         Url::parse(&(host.as_ref().unwrap().to_owned() + &query_path)[..]).unwrap();
                     drop(host);
 
                     // TODO: check if to_vec is inefficient here
-                    let response = client.get(address).send().await?.bytes().await?.to_vec();
+                    let response = client.get(address).send()?.bytes()?.to_vec();
                     let packets = decode_payload(response)?;
 
                     for packet in packets {
                         {
-                            let on_packet = self.on_packet.read().unwrap();
+                            let on_packet = self.on_packet.read()?;
                             // call the packet callback
                             if let Some(function) = on_packet.as_ref() {
                                 spawn_scoped!(function(packet.clone()));
@@ -273,7 +265,7 @@ impl TransportClient {
                         // check for the appropiate action or callback
                         match packet.packet_id {
                             PacketId::Message => {
-                                let on_data = self.on_data.read().unwrap();
+                                let on_data = self.on_data.read()?;
                                 if let Some(function) = on_data.as_ref() {
                                     spawn_scoped!(function(packet.data));
                                 }
@@ -281,7 +273,7 @@ impl TransportClient {
                             }
 
                             PacketId::Close => {
-                                let on_close = self.on_close.read().unwrap();
+                                let on_close = self.on_close.read()?;
                                 if let Some(function) = on_close.as_ref() {
                                     spawn_scoped!(function(()));
                                 }
@@ -299,7 +291,7 @@ impl TransportClient {
                             }
                             PacketId::Ping => {
                                 last_ping = Instant::now();
-                                self.emit(Packet::new(PacketId::Pong, Vec::new())).await?;
+                                self.emit(Packet::new(PacketId::Pong, Vec::new()))?;
                             }
                             PacketId::Pong => {
                                 // this will never happen as the pong packet is
@@ -318,7 +310,7 @@ impl TransportClient {
                 }
             }
         }
-        return Ok(());
+        Ok(())
     }
 
     /// Produces a random String that is used to prevent browser caching.
@@ -331,12 +323,14 @@ impl TransportClient {
 
     /// Calls the error callback with a given message.
     #[inline]
-    fn call_error_callback(&self, text: String) {
-        let function = self.on_error.read().unwrap();
+    fn call_error_callback(&self, text: String) -> Result<(), Error> {
+        let function = self.on_error.read()?;
         if let Some(function) = function.as_ref() {
             spawn_scoped!(function(text));
         }
         drop(function);
+
+        Ok(())
     }
 
     // Constructs the path for a request, depending on the different situations.
@@ -413,26 +407,22 @@ mod test {
 
     use super::*;
 
-    #[actix_rt::test]
-    async fn test_connection() {
+    #[test]
+    fn test_connection() {
         let mut socket = TransportClient::new(true);
-        socket
-            .open("http://localhost:4200".to_owned())
-            .await
-            .unwrap();
+        socket.open("http://localhost:4200").unwrap();
 
         socket
             .emit(Packet::new(
                 PacketId::Message,
                 "HelloWorld".to_string().into_bytes(),
             ))
-            .await
             .unwrap();
 
         socket.on_data = Arc::new(RwLock::new(Some(Box::new(|data| {
             println!("Received: {:?}", std::str::from_utf8(&data).unwrap());
         }))));
 
-        socket.poll_cycle().await.unwrap();
+        socket.poll_cycle().unwrap();
     }
 }

--- a/src/engineio/transport.rs
+++ b/src/engineio/transport.rs
@@ -409,6 +409,7 @@ mod test {
     use crate::engineio::packet::{Packet, PacketId};
 
     use super::*;
+    /// The engine.io server for testing runs on port 4201
     const SERVER_URL: &str = "http://localhost:4201";
 
     #[test]
@@ -419,7 +420,7 @@ mod test {
         assert!(socket
             .emit(Packet::new(
                 PacketId::Message,
-                "HelloWorld".to_string().into_bytes(),
+                "HelloWorld".to_owned().into_bytes(),
             ))
             .is_ok());
 
@@ -430,10 +431,11 @@ mod test {
             );
         }))));
 
+        // closes the connection
         assert!(socket
             .emit(Packet::new(
                 PacketId::Message,
-                "PlsEnd".to_string().into_bytes(),
+                "CLOSE".to_owned().into_bytes(),
             ))
             .is_ok());
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,56 +18,65 @@ pub enum Error {
     InvalidJson(String),
     DidNotReceiveProperAck(i32),
     IllegalActionAfterOpen,
+    PoisonedLockError,
 }
 
 impl From<DecodeError> for Error {
     fn from(error: DecodeError) -> Self {
-        Error::Base64Error(error)
+        Self::Base64Error(error)
+    }
+}
+
+impl<T> From<std::sync::PoisonError<T>> for Error {
+    fn from(_: std::sync::PoisonError<T>) -> Self {
+        Self::PoisonedLockError
     }
 }
 
 impl From<str::Utf8Error> for Error {
     fn from(error: str::Utf8Error) -> Self {
-        Error::Utf8Error(error)
+        Self::Utf8Error(error)
     }
 }
 
 impl From<reqwest::Error> for Error {
     fn from(error: reqwest::Error) -> Self {
-        Error::ReqwestError(error)
+        Self::ReqwestError(error)
     }
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self {
-            Error::InvalidPacketId(id) => write!(f, "Invalid packet id: {}", id),
-            Error::EmptyPacket => write!(f, "Error while parsing an empty packet"),
-            Error::IncompletePacket => write!(f, "Error while parsing an incomplete packet"),
-            Error::Utf8Error(e) => {
+            Self::InvalidPacketId(id) => write!(f, "Invalid packet id: {}", id),
+            Self::EmptyPacket => write!(f, "Error while parsing an empty packet"),
+            Self::IncompletePacket => write!(f, "Error while parsing an incomplete packet"),
+            Self::Utf8Error(e) => {
                 write!(f, "An error occured while decoding the utf-8 text: {}", e)
             }
-            Error::Base64Error(e) => {
+            Self::Base64Error(e) => {
                 write!(f, "An error occured while encoding/decoding base64: {}", e)
             }
-            Error::InvalidUrl(url) => write!(f, "Unable to connect to: {}", url),
-            Error::ReqwestError(error) => {
+            Self
+            ::InvalidUrl(url) => write!(f, "Unable to connect to: {}", url),
+            Self::ReqwestError(error) => {
                 write!(f, "Error during connection via Reqwest: {}", error)
             }
-            Error::HandshakeError(response) => {
+            Self::HandshakeError(response) => {
                 write!(f, "Got illegal handshake response: {}", response)
             }
-            Error::ActionBeforeOpen => {
+            Self::ActionBeforeOpen => {
                 write!(f, "Called an action before the connection was established")
             }
-            Error::HttpError(status_code) => write!(
+            Self::HttpError(status_code) => write!(
                 f,
                 "Network request returned with status code: {}",
                 status_code
             ),
-            Error::InvalidJson(string) => write!(f, "string is not json serializable: {}", string),
-            Error::DidNotReceiveProperAck(id) => write!(f, "Did not receive an ack for id: {}", id),
-            Error::IllegalActionAfterOpen => write!(f, "An illegal action (such as setting a callback after being connected) was triggered")
+            Self::InvalidJson(string) => write!(f, "string is not json serializable: {}", string),
+            Self::DidNotReceiveProperAck(id) => write!(f, "Did not receive an ack for id: {}", id),
+            Self::IllegalActionAfterOpen => write!(f, "An illegal action (such as setting a callback after being connected) was triggered"),
+            Self::PoisonedLockError => write!(f, "A lock was poisoned")
         }
     }
 }

--- a/src/socketio/event.rs
+++ b/src/socketio/event.rs
@@ -30,10 +30,10 @@ impl From<&str> for Event {
 impl From<Event> for String {
     fn from(event: Event) -> Self {
         match event {
-            Event::Message => String::from("message"),
-            Event::Connect => String::from("open"),
-            Event::Close => String::from("close"),
-            Event::Error => String::from("error"),
+            Event::Message => Self::from("message"),
+            Event::Connect => Self::from("open"),
+            Event::Close => Self::from("close"),
+            Event::Error => Self::from("error"),
             Event::Custom(string) => string,
         }
     }

--- a/src/socketio/packet.rs
+++ b/src/socketio/packet.rs
@@ -24,9 +24,9 @@ pub struct Packet {
     pub attachements: Option<u8>,
 }
 
-/// Converts an u8 byte to a PacketId.
+/// Converts an u8 byte to a `PacketId`.
 #[inline]
-pub fn u8_to_packet_id(b: u8) -> Result<PacketId, Error> {
+pub const fn u8_to_packet_id(b: u8) -> Result<PacketId, Error> {
     match b as char {
         '0' => Ok(PacketId::Connect),
         '1' => Ok(PacketId::Disconnect),
@@ -41,7 +41,7 @@ pub fn u8_to_packet_id(b: u8) -> Result<PacketId, Error> {
 
 impl Packet {
     /// Creates an instance.
-    pub fn new(
+    pub const fn new(
         packet_type: PacketId,
         nsp: String,
         data: Option<String>,
@@ -217,7 +217,7 @@ impl Packet {
                         .to_string()
                         .replace("{\"_placeholder\":true,\"num\":0}", "");
 
-                    if str.starts_with("[") {
+                    if str.starts_with('[') {
                         str.remove(0);
                     }
                     str = re_close.replace(&str, "").to_string();

--- a/src/socketio/packet.rs
+++ b/src/socketio/packet.rs
@@ -212,12 +212,14 @@ impl Packet {
                             .to_vec(),
                     );
 
-                    let re_open = Regex::new(r"^\[").unwrap();
                     let re_close = Regex::new(r",]$|]$").unwrap();
                     let mut str = json_data
                         .to_string()
                         .replace("{\"_placeholder\":true,\"num\":0}", "");
-                    str = re_open.replace(&str, "").to_string();
+
+                    if str.starts_with("[") {
+                        str.remove(0);
+                    }
                     str = re_close.replace(&str, "").to_string();
 
                     if str.is_empty() {

--- a/src/socketio/transport.rs
+++ b/src/socketio/transport.rs
@@ -178,6 +178,7 @@ impl TransportClient {
     /// Handles the incoming messages and classifies what callbacks to call and how.
     /// This method is later registered as the callback for the `on_data` event of the
     /// engineio client.
+    #[inline]
     fn handle_new_message(socket_bytes: Vec<u8>, clone_self: &TransportClient) {
         if let Ok(socket_packet) =
             SocketPacket::decode_string(std::str::from_utf8(&socket_bytes).unwrap().to_owned())
@@ -227,6 +228,8 @@ impl TransportClient {
         }
     }
 
+    /// Handles the incoming acks and classifies what callbacks to call and how.
+    #[inline]
     fn handle_ack(socket_packet: SocketPacket, clone_self: &TransportClient) {
         let mut to_be_removed = Vec::new();
         if let Some(id) = socket_packet.id {
@@ -375,6 +378,7 @@ mod test {
     use std::time::Duration;
 
     use super::*;
+    /// The socket.io server for testing runs on port 4200
     const SERVER_URL: &str = "http://localhost:4200";
 
     #[test]

--- a/src/socketio/transport.rs
+++ b/src/socketio/transport.rs
@@ -62,7 +62,7 @@ impl TransportClient {
         F: FnMut(String) + 'static + Sync + Send,
     {
         Arc::get_mut(&mut self.on)
-            .ok_or(Error::PoisonedLockError)?
+            .unwrap()
             .push((event, RwLock::new(Box::new(callback))));
         Ok(())
     }


### PR DESCRIPTION
During development I've often came across problems related to async rust. When I started the project I thought it would be a nice thing to have the whole crate use rusts async API, but now it just feels like it decreases the development speed. As this is mostly a learning project for me, I think it might be a good idea to refactor the code to be normal, sync rust. We might switch back to async later, when the whole protocol is implemented and the API is fix.

Changes in this PR:

- Removed all async code (originated from the async HTTP requests made via reqwest).
- Changed the callback functions of the socket.io client from `Fn` to `FnMut`, because this allows using the socket within the callback.