### PR TITLE
Refactored packet decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 
 [dependencies]
 base64 = "0.13.0"
+bytes = "1"
 rand = "0.8.1"
 crossbeam-utils = "0.8.1"
 reqwest = { version = "0.11.0", features = ["blocking"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,10 @@
 //! this as soon as possible.
 //!
 #![allow(clippy::rc_buffer)]
+#![warn(clippy::complexity)]
+#![warn(clippy::style)]
+#![warn(clippy::perf)]
+#![warn(clippy::correctness)]
 /// A small macro that spawns a scoped thread. Used for calling the callback
 /// functions.
 macro_rules! spawn_scoped {

--- a/src/socketio/packet.rs
+++ b/src/socketio/packet.rs
@@ -111,22 +111,23 @@ impl Packet {
         buffer
     }
 
-    /// Decodes a packet given an utf-8 string.
-    pub fn decode_string(string: String) -> Result<Self, Error> {
+    /// Decodes a packet given a `Vec<u8>`.
+    pub fn decode_bytes(payload: Vec<u8>) -> Result<Self, Error> {
         let mut i = 0;
-        let packet_id = u8_to_packet_id(string.as_bytes()[i])?;
+        let packet_id = u8_to_packet_id(*payload.first().ok_or(Error::EmptyPacket)?)?;
 
         let attachements = if let PacketId::BinaryAck | PacketId::BinaryEvent = packet_id {
             let start = i + 1;
 
-            while string.chars().nth(i).ok_or(Error::IncompletePacket)? != '-' && i < string.len() {
+            while payload.get(i).ok_or(Error::IncompletePacket)? != &b'-' && i < payload.len() {
                 i += 1;
             }
             Some(
-                string
-                    .chars()
+                payload
+                    .iter()
                     .skip(start)
                     .take(i - start)
+                    .map(|byte| *byte as char)
                     .collect::<String>()
                     .parse::<u8>()?,
             )
@@ -134,39 +135,37 @@ impl Packet {
             None
         };
 
-        let nsp = if string.chars().nth(i + 1).ok_or(Error::IncompletePacket)? == '/' {
+        let nsp = if payload.get(i + 1).ok_or(Error::IncompletePacket)? == &b'/' {
             let start = i + 1;
-            while string.chars().nth(i).ok_or(Error::IncompletePacket)? != ',' && i < string.len() {
+            while payload.get(i).ok_or(Error::IncompletePacket)? != &b',' && i < payload.len() {
                 i += 1;
             }
-            string
-                .chars()
+            payload
+                .iter()
                 .skip(start)
                 .take(i - start)
+                .map(|byte| *byte as char)
                 .collect::<String>()
         } else {
             String::from("/")
         };
 
-        let next = string.chars().nth(i + 1).unwrap_or('_');
-        let id = if next.is_digit(10) && i < string.len() {
+        let next = payload.get(i + 1).unwrap_or(&b'_');
+        let id = if (*next as char).is_digit(10) && i < payload.len() {
             let start = i + 1;
             i += 1;
-            while string
-                .chars()
-                .nth(i)
-                .ok_or(Error::IncompletePacket)?
-                .is_digit(10)
-                && i < string.len()
+            while (*payload.get(i).ok_or(Error::IncompletePacket)? as char).is_digit(10)
+                && i < payload.len()
             {
                 i += 1;
             }
 
             Some(
-                string
-                    .chars()
+                payload
+                    .iter()
                     .skip(start)
                     .take(i - start)
+                    .map(|byte| *byte as char)
                     .collect::<String>()
                     .parse::<i32>()?,
             )
@@ -175,17 +174,18 @@ impl Packet {
         };
 
         let mut binary_data = None;
-        let data = if string.chars().nth(i + 1).is_some() {
+        let data = if payload.get(i + 1).is_some() {
             let start = if id.is_some() { i } else { i + 1 };
 
             let mut json_data = serde_json::Value::Null;
 
-            let mut end = string.len();
+            let mut end = payload.len();
             while serde_json::from_str::<serde_json::Value>(
-                &string
-                    .chars()
+                &payload
+                    .iter()
                     .skip(start)
                     .take(end - start)
+                    .map(|byte| *byte as char)
                     .collect::<String>(),
             )
             .is_err()
@@ -197,10 +197,11 @@ impl Packet {
                 // unwrapping here is infact safe as we checked for errors in the
                 // condition of the loop
                 json_data = serde_json::from_str(
-                    &string
-                        .chars()
+                    &payload
+                        .iter()
                         .skip(start)
                         .take(end - start)
+                        .map(|byte| *byte as char)
                         .collect::<String>(),
                 )
                 .unwrap();
@@ -209,13 +210,12 @@ impl Packet {
             match packet_id {
                 PacketId::BinaryAck | PacketId::BinaryEvent => {
                     binary_data = Some(
-                        string
-                            .chars()
+                        payload
+                            .iter()
                             .skip(end)
-                            .take(string.len() - end)
-                            .collect::<String>()
-                            .as_bytes()
-                            .to_vec(),
+                            .take(payload.len() - end)
+                            .copied()
+                            .collect(),
                     );
 
                     let re_close = Regex::new(r",]$|]$").unwrap();
@@ -259,7 +259,7 @@ mod test {
     /// This test suite is taken from the explanation section here:
     /// https://github.com/socketio/socket.io-protocol
     fn test_decode() {
-        let packet = Packet::decode_string("0{\"token\":\"123\"}".to_string());
+        let packet = Packet::decode_bytes("0{\"token\":\"123\"}".as_bytes().to_vec());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -274,7 +274,7 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_string("0/admin,{\"token\":\"123\"}".to_string());
+        let packet = Packet::decode_bytes("0/admin,{\"token\":\"123\"}".as_bytes().to_vec());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -289,7 +289,7 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_string("1/admin,".to_string());
+        let packet = Packet::decode_bytes("1/admin,".as_bytes().to_vec());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -304,7 +304,7 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_string("2[\"hello\",1]".to_string());
+        let packet = Packet::decode_bytes("2[\"hello\",1]".as_bytes().to_vec());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -319,7 +319,8 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_string("2/admin,456[\"project:delete\",123]".to_string());
+        let packet =
+            Packet::decode_bytes("2/admin,456[\"project:delete\",123]".as_bytes().to_vec());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -334,7 +335,7 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_string("3/admin,456[]".to_string());
+        let packet = Packet::decode_bytes("3/admin,456[]".as_bytes().to_vec());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -349,7 +350,11 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_string("4/admin,{\"message\":\"Not authorized\"}".to_string());
+        let packet = Packet::decode_bytes(
+            "4/admin,{\"message\":\"Not authorized\"}"
+                .as_bytes()
+                .to_vec(),
+        );
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -364,8 +369,10 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_string(
-            "51-[\"hello\",{\"_placeholder\":true,\"num\":0}]\x01\x02\x03".to_string(),
+        let packet = Packet::decode_bytes(
+            "51-[\"hello\",{\"_placeholder\":true,\"num\":0}]\x01\x02\x03"
+                .as_bytes()
+                .to_vec(),
         );
         assert!(packet.is_ok());
 
@@ -381,9 +388,10 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_string(
+        let packet = Packet::decode_bytes(
             "51-/admin,456[\"project:delete\",{\"_placeholder\":true,\"num\":0}]\x01\x02\x03"
-                .to_string(),
+                .as_bytes()
+                .to_vec(),
         );
         assert!(packet.is_ok());
 
@@ -399,8 +407,10 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_string(
-            "61-/admin,456[{\"_placeholder\":true,\"num\":0}]\x03\x02\x01".to_string(),
+        let packet = Packet::decode_bytes(
+            "61-/admin,456[{\"_placeholder\":true,\"num\":0}]\x03\x02\x01"
+                .as_bytes()
+                .to_vec(),
         );
         assert!(packet.is_ok());
 

--- a/src/socketio/packet.rs
+++ b/src/socketio/packet.rs
@@ -111,8 +111,8 @@ impl Packet {
         buffer
     }
 
-    /// Decodes a packet given a `Vec<u8>`.
-    pub fn decode_bytes(payload: Vec<u8>) -> Result<Self, Error> {
+    /// Decodes a packet given a `&[u8]`.
+    pub fn decode_bytes(payload: &[u8]) -> Result<Self, Error> {
         let mut i = 0;
         let packet_id = u8_to_packet_id(*payload.first().ok_or(Error::EmptyPacket)?)?;
 
@@ -259,7 +259,7 @@ mod test {
     /// This test suite is taken from the explanation section here:
     /// https://github.com/socketio/socket.io-protocol
     fn test_decode() {
-        let packet = Packet::decode_bytes("0{\"token\":\"123\"}".as_bytes().to_vec());
+        let packet = Packet::decode_bytes("0{\"token\":\"123\"}".as_bytes());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -274,7 +274,7 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_bytes("0/admin,{\"token\":\"123\"}".as_bytes().to_vec());
+        let packet = Packet::decode_bytes("0/admin,{\"token\":\"123\"}".as_bytes());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -289,7 +289,7 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_bytes("1/admin,".as_bytes().to_vec());
+        let packet = Packet::decode_bytes("1/admin,".as_bytes());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -304,7 +304,7 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_bytes("2[\"hello\",1]".as_bytes().to_vec());
+        let packet = Packet::decode_bytes("2[\"hello\",1]".as_bytes());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -319,8 +319,7 @@ mod test {
             packet.unwrap()
         );
 
-        let packet =
-            Packet::decode_bytes("2/admin,456[\"project:delete\",123]".as_bytes().to_vec());
+        let packet = Packet::decode_bytes("2/admin,456[\"project:delete\",123]".as_bytes());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -335,7 +334,7 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_bytes("3/admin,456[]".as_bytes().to_vec());
+        let packet = Packet::decode_bytes("3/admin,456[]".as_bytes());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -350,11 +349,7 @@ mod test {
             packet.unwrap()
         );
 
-        let packet = Packet::decode_bytes(
-            "4/admin,{\"message\":\"Not authorized\"}"
-                .as_bytes()
-                .to_vec(),
-        );
+        let packet = Packet::decode_bytes("4/admin,{\"message\":\"Not authorized\"}".as_bytes());
         assert!(packet.is_ok());
 
         assert_eq!(
@@ -370,9 +365,7 @@ mod test {
         );
 
         let packet = Packet::decode_bytes(
-            "51-[\"hello\",{\"_placeholder\":true,\"num\":0}]\x01\x02\x03"
-                .as_bytes()
-                .to_vec(),
+            "51-[\"hello\",{\"_placeholder\":true,\"num\":0}]\x01\x02\x03".as_bytes(),
         );
         assert!(packet.is_ok());
 
@@ -390,8 +383,7 @@ mod test {
 
         let packet = Packet::decode_bytes(
             "51-/admin,456[\"project:delete\",{\"_placeholder\":true,\"num\":0}]\x01\x02\x03"
-                .as_bytes()
-                .to_vec(),
+                .as_bytes(),
         );
         assert!(packet.is_ok());
 
@@ -408,9 +400,7 @@ mod test {
         );
 
         let packet = Packet::decode_bytes(
-            "61-/admin,456[{\"_placeholder\":true,\"num\":0}]\x03\x02\x01"
-                .as_bytes()
-                .to_vec(),
+            "61-/admin,456[{\"_placeholder\":true,\"num\":0}]\x03\x02\x01".as_bytes(),
         );
         assert!(packet.is_ok());
 

--- a/src/socketio/transport.rs
+++ b/src/socketio/transport.rs
@@ -180,9 +180,7 @@ impl TransportClient {
     /// engineio client.
     #[inline]
     fn handle_new_message(socket_bytes: Vec<u8>, clone_self: &TransportClient) {
-        if let Ok(socket_packet) =
-            SocketPacket::decode_string(std::str::from_utf8(&socket_bytes).unwrap().to_owned())
-        {
+        if let Ok(socket_packet) = SocketPacket::decode_bytes(socket_bytes) {
             if socket_packet.nsp
                 != clone_self
                     .nsp

--- a/src/socketio/transport.rs
+++ b/src/socketio/transport.rs
@@ -180,8 +180,8 @@ impl TransportClient {
     /// This method is later registered as the callback for the `on_data` event of the
     /// engineio client.
     #[inline]
-    fn handle_new_message(socket_bytes: Vec<u8>, clone_self: &TransportClient) {
-        if let Ok(socket_packet) = SocketPacket::decode_bytes(socket_bytes) {
+    fn handle_new_message(socket_bytes: &[u8], clone_self: &TransportClient) {
+        if let Ok(socket_packet) = SocketPacket::decode_bytes(&socket_bytes) {
             if socket_packet.nsp
                 != clone_self
                     .nsp
@@ -301,7 +301,7 @@ impl TransportClient {
         let clone_self = self.clone();
         self.engine_socket
             .lock()?
-            .on_data(move |data| Self::handle_new_message(data, &clone_self))
+            .on_data(move |data| Self::handle_new_message(&data, &clone_self))
     }
 
     /// A method for handling the Event Socket Packets.


### PR DESCRIPTION
This PR refactors the way the `socket.io` packet decoder parses the packet. Till now this was done via parsing the packet from a string, which involved parsing an utf-8 string. This PR changes this by parsing the packet from pure bytes.