### PR TITLE
Added a disconnect method for the socket.io socket

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,9 +25,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Install covfix
-        run: cargo install rust-covfix
-
       - name: Build docker container
         run: |
           cd ci && docker build -t test_suite:latest .

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: "0.18.0-alpha3"
+          out-type: Lcov
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,16 +14,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup rust environment  
+      - name: Setup rust environment
         uses: actions-rs/toolchain@v1
         with:
-             profile: minimal
-             toolchain: stable
-             override: true
+          profile: minimal
+          toolchain: stable
+          override: true
 
       - name: Setup docker
         id: buildx
         uses: docker/setup-buildx-action@v1
+
+      - name: Install covfix
+        run: cargo install rust-covfix
 
       - name: Build docker container
         run: |
@@ -33,7 +36,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.15.0'
+          version: "0.18.0-alpha3"
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1.0.2

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,11 @@
 coverage:
+  range: 50..90 # coverage lower than 50 is red, higher than 90 green, between color code
+
   status:
-    project:
+    project: # settings affecting project coverage
       default:
-        target: auto
-        threshold: 100%
-        paths: 
-          - "src"
-        branches: 
-          - main
-        if_ci_failed: ignore
-        informational: false
-        only_pulls: false
+        target: auto # auto % coverage target
+        threshold: 5%  # allow for 5% reduction of coverage without failing
+
+    # do not run coverage on patch nor changes
+    patch: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 2%
+        threshold: 100%
         paths: 
           - "src"
         branches: 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,6 +382,33 @@ impl Socket {
         self.transport.emit(event.into(), data.into())
     }
 
+    /// Disconnects this client from the server by sending a `socket.io` closing
+    /// packet.
+    /// # Example
+    /// ```rust
+    /// use rust_socketio::{SocketBuilder, Payload};
+    /// use serde_json::json;
+    ///
+    /// let mut socket = SocketBuilder::new("http://localhost:4200")
+    ///     .on("test", |payload: Payload, mut socket| {
+    ///         println!("Received: {:#?}", payload);
+    ///         socket.emit("test", json!({"hello": true})).expect("Server unreachable");
+    ///      })
+    ///     .connect()
+    ///     .expect("connection failed");
+    ///
+    /// let json_payload = json!({"token": 123});
+    ///
+    /// socket.emit("foo", json_payload);
+    ///
+    /// // disconnect from the server
+    /// socket.disconnect();
+    ///
+    /// ```
+    pub fn disconnect(&mut self) -> Result<()> {
+        self.transport.disconnect()
+    }
+
     /// Sends a message to the server but `alloc`s an `ack` to check whether the
     /// server responded in a given timespan. This message takes an event, which
     /// could either be one of the common events like "message" or "error" or a
@@ -491,6 +518,9 @@ mod test {
             ack_callback,
         );
         assert!(ack.is_ok());
+
+        socket.disconnect().unwrap();
+        // assert!(socket.disconnect().is_ok());
 
         sleep(Duration::from_secs(4));
     }


### PR DESCRIPTION
The current implementation missed a disconnection ability for the `socket.io` socket, as mentioned in #43.