### PR TITLE
feat: devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
 
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [
-        "rust-lang.rust",
+        "matklad.rust-analyzer",
         "bungcip.better-toml",
         "vadimcn.vscode-lldb",
         "mutantdino.resourcemonitor",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/rust
+{
+	"name": "Rust",
+    "dockerComposeFile": ["../docker-compose.yaml"],
+    "service": "rust-client",
+	"workspaceFolder": "/workspace/rust-socketio",
+    "shutdownAction": "stopCompose",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"lldb.executable": "/usr/bin/lldb",
+		// VS Code don't watch files under ./target
+		"files.watcherExclude": {
+			"**/target/**": true
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"rust-lang.rust",
+		"bungcip.better-toml",
+		"vadimcn.vscode-lldb",
+		"mutantdino.resourcemonitor"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,33 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/rust
 {
-	"name": "Rust",
+    "name": "Rust",
     "dockerComposeFile": ["../docker-compose.yaml"],
     "service": "rust-client",
-	"workspaceFolder": "/workspace/rust-socketio",
+    "workspaceFolder": "/workspace/rust-socketio",
     "shutdownAction": "stopCompose",
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"lldb.executable": "/usr/bin/lldb",
-		// VS Code don't watch files under ./target
-		"files.watcherExclude": {
-			"**/target/**": true
-		}
-	},
+    // Set *default* container specific settings.json values on container create.
+    "settings": { 
+        "lldb.executable": "/usr/bin/lldb",
+        // VS Code don't watch files under ./target
+        "files.watcherExclude": {
+            "**/target/**": true
+        }
+    },
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"rust-lang.rust",
-		"bungcip.better-toml",
-		"vadimcn.vscode-lldb",
-		"mutantdino.resourcemonitor",
-		"eamodio.gitlens"
-	],
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "rust-lang.rust",
+        "bungcip.better-toml",
+        "vadimcn.vscode-lldb",
+        "mutantdino.resourcemonitor",
+        "eamodio.gitlens"
+    ],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
 
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
 
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [
-        "matklad.rust-analyzer",
+        "rust-lang.rust",
         "bungcip.better-toml",
         "vadimcn.vscode-lldb",
         "mutantdino.resourcemonitor",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,14 +21,12 @@
 		"rust-lang.rust",
 		"bungcip.better-toml",
 		"vadimcn.vscode-lldb",
-		"mutantdino.resourcemonitor"
+		"mutantdino.resourcemonitor",
+		"eamodio.gitlens"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/rust
 {
     "name": "Rust",
-    "dockerComposeFile": ["../docker-compose.yaml"],
+    "dockerComposeFile": ["./docker-compose.yaml"],
     "service": "rust-client",
     "workspaceFolder": "/workspace/rust-socketio",
     "shutdownAction": "stopCompose",

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -2,19 +2,19 @@ version: '3'
 services:
     node-engine-io-secure:
         build:
-            context: ./ci
+            context: ../ci
         command: [ "node", "/test/engine-io-secure.js" ]
         ports:
             - "4202:4202"
     node-engine-io:
         build:
-            context: ./ci
+            context: ../ci
         command: [ "node", "/test/engine-io.js" ]
         ports:
             - "4201:4201"
     node-socket-io:
         build:
-            context: ./ci
+            context: ../ci
         command: [ "node", "/test/socket-io.js" ]
         ports:
             - "4200:4200"
@@ -22,7 +22,7 @@ services:
         image: mcr.microsoft.com/vscode/devcontainers/rust:0-1
         command: /bin/sh -c "while sleep 10000d; do :; done"
         volumes: 
-            - ".:/workspace/rust-socketio"
+            - "..:/workspace/rust-socketio"
         environment:
             - "SOCKET_IO_SERVER=http://node-socket-io:4200"
             - "ENGINE_IO_SERVER=http://node-engine-io:4201"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: '3'
+services:
+    node-engine-io-secure:
+        build:
+            context: ./ci
+        command: [ "node", "/test/engine-io-secure.js" ]
+        ports:
+            - "4202:4202"
+    node-engine-io:
+        build:
+            context: ./ci
+        command: [ "node", "/test/engine-io.js" ]
+        ports:
+            - "4201:4201"
+    node-socket-io:
+        build:
+            context: ./ci
+        command: [ "node", "/test/socket-io.js" ]
+        ports:
+            - "4200:4200"
+    rust-client:
+        image: mcr.microsoft.com/vscode/devcontainers/rust:0-1
+        command: /bin/sh -c "while sleep 10000d; do :; done"
+        volumes: 
+            - ".:/workspace/rust-socketio"
+        environment:
+            - "SOCKET_IO_SERVER=http://node-socket-io:4200"
+            - "ENGINE_IO_SERVER=http://node-engine-io:4201"
+            - "ENGINE_IO_SECURE_SERVER=https://node-engine-io-secure:4202"
+            - "ENGINE_IO_SECURE_HOST=node-engine-io-secure"

--- a/src/engineio/socket.rs
+++ b/src/engineio/socket.rs
@@ -190,7 +190,9 @@ mod test {
             })
             .is_ok());
 
-        assert!(socket.bind(SERVER_URL).is_ok());
+        let url = std::env::var("ENGINE_IO_SERVER").unwrap_or_else(|_| SERVER_URL.to_owned());
+
+        assert!(socket.bind(url).is_ok());
 
         assert!(socket
             .emit(Packet::new(
@@ -229,7 +231,9 @@ mod test {
             .is_err());
         assert!(sut.emit_binary_attachment(Bytes::from_static(b"")).is_err());
 
-        assert!(sut.bind(SERVER_URL).is_ok());
+        let url = std::env::var("ENGINE_IO_SERVER").unwrap_or_else(|_| SERVER_URL.to_owned());
+
+        assert!(sut.bind(url).is_ok());
 
         assert!(sut.on_open(|_| {}).is_err());
         assert!(sut.on_close(|_| {}).is_err());

--- a/src/engineio/transport.rs
+++ b/src/engineio/transport.rs
@@ -711,7 +711,9 @@ mod test {
     fn test_connection_polling() {
         let mut socket = TransportClient::new(true, None, None);
 
-        socket.open(SERVER_URL).unwrap();
+        let url = std::env::var("ENGINE_IO_SERVER").unwrap_or_else(|_| SERVER_URL.to_owned());
+
+        socket.open(url).unwrap();
 
         assert!(socket
             .emit(
@@ -747,8 +749,10 @@ mod test {
 
     #[test]
     fn test_connection_secure_ws_http() {
+        let host = std::env::var("ENGINE_IO_SECURE_HOST").unwrap_or_else(|_| "localhost".to_owned());
+
         let mut headers = HeaderMap::new();
-        headers.insert(HOST, "localhost".parse().unwrap());
+        headers.insert(HOST, host.parse().unwrap());
         let mut socket = TransportClient::new(
             true,
             Some(
@@ -760,7 +764,9 @@ mod test {
             Some(headers),
         );
 
-        socket.open(SERVER_URL_SECURE).unwrap();
+        let url = std::env::var("ENGINE_IO_SECURE_SERVER").unwrap_or_else(|_| SERVER_URL_SECURE.to_owned());
+
+        socket.open(url).unwrap();
 
         assert!(socket
             .emit(
@@ -822,7 +828,8 @@ mod test {
 
         // test missing match arm in socket constructor
         let mut headers = HeaderMap::new();
-        headers.insert(HOST, "localhost".parse().unwrap());
+        let host = std::env::var("ENGINE_IO_SECURE_HOST").unwrap_or_else(|_| "localhost".to_owned());
+        headers.insert(HOST, host.parse().unwrap());
 
         let _ = TransportClient::new(
             true,

--- a/src/engineio/transport.rs
+++ b/src/engineio/transport.rs
@@ -749,7 +749,8 @@ mod test {
 
     #[test]
     fn test_connection_secure_ws_http() {
-        let host = std::env::var("ENGINE_IO_SECURE_HOST").unwrap_or_else(|_| "localhost".to_owned());
+        let host =
+            std::env::var("ENGINE_IO_SECURE_HOST").unwrap_or_else(|_| "localhost".to_owned());
 
         let mut headers = HeaderMap::new();
         headers.insert(HOST, host.parse().unwrap());
@@ -764,7 +765,8 @@ mod test {
             Some(headers),
         );
 
-        let url = std::env::var("ENGINE_IO_SECURE_SERVER").unwrap_or_else(|_| SERVER_URL_SECURE.to_owned());
+        let url = std::env::var("ENGINE_IO_SECURE_SERVER")
+            .unwrap_or_else(|_| SERVER_URL_SECURE.to_owned());
 
         socket.open(url).unwrap();
 
@@ -828,7 +830,8 @@ mod test {
 
         // test missing match arm in socket constructor
         let mut headers = HeaderMap::new();
-        let host = std::env::var("ENGINE_IO_SECURE_HOST").unwrap_or_else(|_| "localhost".to_owned());
+        let host =
+            std::env::var("ENGINE_IO_SECURE_HOST").unwrap_or_else(|_| "localhost".to_owned());
         headers.insert(HOST, host.parse().unwrap());
 
         let _ = TransportClient::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,7 +478,9 @@ mod test {
 
     #[test]
     fn it_works() {
-        let mut socket = Socket::new(SERVER_URL, None, None, None);
+        let url = std::env::var("SOCKET_IO_SERVER").unwrap_or_else(|_| SERVER_URL.to_owned());
+
+        let mut socket = Socket::new(url, None, None, None);
 
         let result = socket.on(
             "test".into(),
@@ -527,13 +529,15 @@ mod test {
 
     #[test]
     fn test_builder() {
+        let url = std::env::var("SOCKET_IO_SERVER").unwrap_or_else(|_| SERVER_URL.to_owned());
+
         // expect an illegal namespace
-        assert!(SocketBuilder::new(SERVER_URL)
+        assert!(SocketBuilder::new(url.clone())
             .set_namespace("illegal")
             .is_err());
 
         // test socket build logic
-        let socket_builder = SocketBuilder::new(SERVER_URL);
+        let socket_builder = SocketBuilder::new(url);
 
         let tls_connector = TlsConnector::builder()
             .use_sni(true)

--- a/src/socketio/transport.rs
+++ b/src/socketio/transport.rs
@@ -558,7 +558,10 @@ mod test {
 
     #[test]
     fn it_works() {
-        let mut socket = TransportClient::new(SERVER_URL, None, None, None);
+
+        let url = std::env::var("SOCKET_IO_SERVER").unwrap_or_else(|_| SERVER_URL.to_owned());
+
+        let mut socket = TransportClient::new(url, None, None, None);
 
         assert!(socket
             .on(

--- a/src/socketio/transport.rs
+++ b/src/socketio/transport.rs
@@ -558,7 +558,6 @@ mod test {
 
     #[test]
     fn it_works() {
-
         let url = std::env::var("SOCKET_IO_SERVER").unwrap_or_else(|_| SERVER_URL.to_owned());
 
         let mut socket = TransportClient::new(url, None, None, None);


### PR DESCRIPTION
Adds a [devcontainer](https://code.visualstudio.com/docs/remote/containers) (VSCode specific). It allows for developers to have a reproducible environment to compile and test. This does not effect existing developers and is purely voluntary.

As the project grows, such as having a [server implementation](https://github.com/1c3t3a/rust-socketio/issues/32) (Which I plan on doing shortly), having all the servers/clients needed for testing available during development speeds up testing.

Also modified the tests to optionally read from an environment variable.