### PR TITLE
ci: Bump codecov action version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
           out-type: Lcov
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1.5.2
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 


### PR DESCRIPTION
Hopefully fixes the `Please provide an upload token from codecov.io with valid arguments` error.