### PR TITLE
0.3.0 refactor errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ byte = "0.2.4"
 websocket = "0.26.2"
 thiserror = "1.0"
 native-tls = "0.2.7"
+
+[dev-dependencies]
+cargo-tarpaulin = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ thiserror = "1.0"
 native-tls = "0.2.7"
 
 [dev-dependencies]
-cargo-tarpaulin = "0.18.0"
+cargo-tarpaulin = "0.18.0-alpha3"

--- a/src/engineio/packet.rs
+++ b/src/engineio/packet.rs
@@ -74,20 +74,20 @@ impl Packet {
     /// Decodes a single `Packet` from an `u8` byte stream.
     fn decode_packet(bytes: Bytes) -> Result<Self> {
         if bytes.is_empty() {
-            return Err(Error::EmptyPacket);
+            return Err(Error::IncompletePacket());
         }
 
-        let is_base64 = *bytes.get(0).ok_or(Error::IncompletePacket)? == b'b';
+        let is_base64 = *bytes.get(0).ok_or(Error::IncompletePacket())? == b'b';
 
         // only 'messages' packets could be encoded
         let packet_id = if is_base64 {
             PacketId::Message
         } else {
-            u8_to_packet_id(*bytes.get(0).ok_or(Error::IncompletePacket)?)?
+            u8_to_packet_id(*bytes.get(0).ok_or(Error::IncompletePacket())?)?
         };
 
         if bytes.len() == 1 && packet_id == PacketId::Message {
-            return Err(Error::IncompletePacket);
+            return Err(Error::IncompletePacket());
         }
 
         let data: Bytes = bytes.slice(1..);

--- a/src/engineio/socket.rs
+++ b/src/engineio/socket.rs
@@ -141,7 +141,7 @@ impl EngineSocket {
             loop {
                 match s.poll_cycle() {
                     Ok(_) => break,
-                    e @ Err(Error::IncompleteHttp(_)) | e @ Err(Error::IncompleteReqwest(_)) => {
+                    e @ Err(Error::IncompleteHttp(_)) | e @ Err(Error::IncompleteResponceFromReqwest(_)) => {
                         panic!("{}", e.unwrap_err())
                     }
                     _ => (),

--- a/src/engineio/socket.rs
+++ b/src/engineio/socket.rs
@@ -127,7 +127,7 @@ impl EngineSocket {
     /// to configure callbacks afterwards.
     pub fn bind<T: Into<String>>(&mut self, address: T) -> Result<()> {
         if self.connected.load(Ordering::Acquire) {
-            return Err(Error::IllegalActionAfterOpen);
+            return Err(Error::IllegalActionAfterOpen());
         }
         self.open(address.into())?;
 
@@ -141,7 +141,7 @@ impl EngineSocket {
             loop {
                 match s.poll_cycle() {
                     Ok(_) => break,
-                    e @ Err(Error::HttpError(_)) | e @ Err(Error::ReqwestError(_)) => {
+                    e @ Err(Error::IncompleteHttp(_)) | e @ Err(Error::IncompleteReqwest(_)) => {
                         panic!("{}", e.unwrap_err())
                     }
                     _ => (),
@@ -152,13 +152,13 @@ impl EngineSocket {
         Ok(())
     }
 
-    /// Registers an `on_open` callback.
+    /// Registers the `on_open` callback.
     pub fn on_open<F>(&mut self, function: F) -> Result<()>
     where
         F: Fn(()) + 'static + Sync + Send,
     {
         if self.is_connected()? {
-            return Err(Error::IllegalActionAfterOpen);
+            return Err(Error::IllegalActionAfterOpen());
         }
         let mut on_open = self.on_open.write()?;
         *on_open = Some(Box::new(function));
@@ -172,7 +172,7 @@ impl EngineSocket {
         F: Fn(String) + 'static + Sync + Send,
     {
         if self.is_connected()? {
-            return Err(Error::IllegalActionAfterOpen);
+            return Err(Error::IllegalActionAfterOpen());
         }
         let mut on_error = self.on_error.write()?;
         *on_error = Some(Box::new(function));
@@ -186,7 +186,7 @@ impl EngineSocket {
         F: Fn(Packet) + 'static + Sync + Send,
     {
         if self.is_connected()? {
-            return Err(Error::IllegalActionAfterOpen);
+            return Err(Error::IllegalActionAfterOpen());
         }
         let mut on_packet = self.on_packet.write()?;
         *on_packet = Some(Box::new(function));
@@ -200,7 +200,7 @@ impl EngineSocket {
         F: Fn(Bytes) + 'static + Sync + Send,
     {
         if self.is_connected()? {
-            return Err(Error::IllegalActionAfterOpen);
+            return Err(Error::IllegalActionAfterOpen());
         }
         let mut on_data = self.on_data.write()?;
         *on_data = Some(Box::new(function));
@@ -214,7 +214,7 @@ impl EngineSocket {
         F: Fn(()) + 'static + Sync + Send,
     {
         if self.is_connected()? {
-            return Err(Error::IllegalActionAfterOpen);
+            return Err(Error::IllegalActionAfterOpen());
         }
         let mut on_close = self.on_close.write()?;
         *on_close = Some(Box::new(function));
@@ -285,7 +285,7 @@ impl EngineSocket {
                         return Ok(());
                     }
 
-                    let error = Error::HandshakeError(response);
+                    let error = Error::InvalidHandshake(response);
                     self.call_error_callback(format!("{}", error))?;
                     return Err(error);
                 }
@@ -345,7 +345,7 @@ impl EngineSocket {
 
             return Ok(());
         }
-        Err(Error::HandshakeError("Error - invalid url".to_owned()))
+        Err(Error::InvalidHandshake("Error - invalid url".to_owned()))
     }
 
     /// Converts between `reqwest::HeaderMap` and `websocket::Headers`, if they're currently set, if not
@@ -382,7 +382,7 @@ impl EngineSocket {
         // expect to receive a probe packet
         let message = client.recv_message()?;
         if message.take_payload() != b"3probe" {
-            return Err(Error::HandshakeError("Error".to_owned()));
+            return Err(Error::InvalidHandshake("Error".to_owned()));
         }
 
         // finally send the upgrade request. the payload `5` stands for an upgrade
@@ -416,7 +416,7 @@ impl EngineSocket {
         // expect to receive a probe packet
         let message = receiver.recv_message()?;
         if message.take_payload() != b"3probe" {
-            return Err(Error::HandshakeError("Error".to_owned()));
+            return Err(Error::InvalidHandshake("Error".to_owned()));
         }
 
         // finally send the upgrade request. the payload `5` stands for an upgrade
@@ -436,7 +436,7 @@ impl EngineSocket {
     /// socketio binary attachment via the boolean attribute `is_binary_att`.
     pub fn emit(&self, packet: Packet, is_binary_att: bool) -> Result<()> {
         if !self.connected.load(Ordering::Acquire) {
-            let error = Error::ActionBeforeOpen;
+            let error = Error::IllegalActionBeforeOpen();
             self.call_error_callback(format!("{}", error))?;
             return Err(error);
         }
@@ -481,7 +481,7 @@ impl EngineSocket {
                 drop(client);
 
                 if status != 200 {
-                    let error = Error::HttpError(status);
+                    let error = Error::IncompleteHttp(status);
                     self.call_error_callback(format!("{}", error))?;
                     return Err(error);
                 }
@@ -521,7 +521,7 @@ impl EngineSocket {
     /// response handling from the server.
     pub fn poll_cycle(&mut self) -> Result<()> {
         if !self.connected.load(Ordering::Acquire) {
-            let error = Error::ActionBeforeOpen;
+            let error = Error::IllegalActionBeforeOpen();
             self.call_error_callback(format!("{}", error))?;
             return Err(error);
         }
@@ -968,7 +968,7 @@ mod test {
         let _error = sut
             .emit(Packet::new(PacketId::Close, Bytes::from_static(b"")), false)
             .expect_err("error");
-        assert!(matches!(Error::ActionBeforeOpen, _error));
+        assert!(matches!(Error::IllegalActionBeforeOpen(), _error));
 
         // test missing match arm in socket constructor
         let mut headers = HeaderMap::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,7 @@ pub enum Error {
     #[error("Invalid Url: {0}")]
     InvalidUrl(String),
     #[error("Error during connection via http: {0}")]
-    IncompleteReqwest(#[from] ReqwestError),
+    IncompleteResponceFromReqwest(#[from] ReqwestError),
     #[error("Network request returned with status code: {0}")]
     IncompleteHttp(u16),
     #[error("Got illegal handshake response: {0}")]
@@ -46,7 +46,7 @@ pub enum Error {
     #[error("A lock was poisoned")]
     InvalidPoisonedLock(),
     #[error("Got a websocket error: {0}")]
-    IncompleteWebsocket(#[from] WebSocketError),
+    IncompleteResponceFromWebsocket(#[from] WebSocketError),
     #[error("Error while parsing the url for the websocket connection: {0}")]
     InvalidWebsocketURL(#[from] ParseError),
     #[error("Got an IO-Error: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,6 +88,7 @@ mod tests {
     /// This just tests the own implementations and relies on `thiserror` for the others.
     #[test]
     fn test_error_conversion() {
+        //TODO: create the errors and test all type conversions
         let mutex = Mutex::new(0);
         let _poison_error = Error::from(PoisonError::new(mutex.lock()));
         assert!(matches!(Error::InvalidPoisonedLock(), _poison_error));

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,7 +51,7 @@ pub enum Error {
     #[error("Error while parsing the url for the websocket connection: {0}")]
     InvalidWebsocketURL(#[from] ParseError),
     #[error("Got an IO-Error: {0}")]
-    IcompleteIo(#[from] IoError),
+    IncompleteIo(#[from] IoError),
     #[error("The socket is closed")]
     IllegalActionAfterClose(),
     #[error("Error while parsing an integer")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,9 @@
 use base64::DecodeError;
-use std::{num::ParseIntError, str};
+use reqwest::Error as ReqwestError;
+use serde_json::Error as JsonError;
+use std::io::Error as IoError;
+use std::num::ParseIntError;
+use std::str::Utf8Error;
 use thiserror::Error;
 use websocket::{client::ParseError, WebSocketError};
 
@@ -7,58 +11,71 @@ use websocket::{client::ParseError, WebSocketError};
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
+    // Conform to https://rust-lang.github.io/api-guidelines/naming.html#names-use-a-consistent-word-order-c-word-order
+    // Negative verb-object
     #[error("Invalid packet id: {0}")]
     InvalidPacketId(u8),
     #[error("Error while parsing an empty packet")]
-    EmptyPacket,
+    EmptyPacket(),
     #[error("Error while parsing an incomplete packet")]
-    IncompletePacket,
+    IncompletePacket(),
     #[error("Got an invalid packet which did not follow the protocol format")]
-    InvalidPacket,
+    InvalidPacket(),
     #[error("An error occurred while decoding the utf-8 text: {0}")]
-    Utf8Error(#[from] str::Utf8Error),
+    InvalidUtf8(#[from] Utf8Error),
     #[error("An error occurred while encoding/decoding base64: {0}")]
-    Base64Error(#[from] DecodeError),
+    InvalidBase64(#[from] DecodeError),
     #[error("Invalid Url: {0}")]
     InvalidUrl(String),
     #[error("Error during connection via http: {0}")]
-    ReqwestError(#[from] reqwest::Error),
+    IncompleteReqwest(#[from] ReqwestError),
     #[error("Network request returned with status code: {0}")]
-    HttpError(u16),
+    IncompleteHttp(u16),
     #[error("Got illegal handshake response: {0}")]
-    HandshakeError(String),
+    InvalidHandshake(String),
     #[error("Called an action before the connection was established")]
-    ActionBeforeOpen,
+    IllegalActionBeforeOpen(),
     #[error("string is not json serializable: {0}")]
-    InvalidJson(#[from] serde_json::Error),
+    InvalidJson(#[from] JsonError),
     #[error("Did not receive an ack for id: {0}")]
-    DidNotReceiveProperAck(i32),
+    MissingAck(i32),
     #[error("An illegal action (such as setting a callback after being connected) was triggered")]
-    IllegalActionAfterOpen,
+    IllegalActionAfterOpen(),
     #[error("Specified namespace {0} is not valid")]
     IllegalNamespace(String),
     #[error("A lock was poisoned")]
-    PoisonedLockError,
+    InvalidPoisonedLock(),
     #[error("Got a websocket error: {0}")]
-    FromWebsocketError(#[from] WebSocketError),
+    IncompleteWebsocket(#[from] WebSocketError),
     #[error("Error while parsing the url for the websocket connection: {0}")]
-    FromWebsocketParseError(#[from] ParseError),
+    InvalidWebsocketURL(#[from] ParseError),
     #[error("Got an IO-Error: {0}")]
-    FromIoError(#[from] std::io::Error),
+    IcompleteIo(#[from] IoError),
+    #[error("The socket is closed")]
+    IllegalActionAfterClose(),
+    #[error("Error while parsing an integer")]
+    InvalidInteger(#[from] ParseIntError),
+    #[error("Missing URL")]
+    MissingUrl(),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 impl<T> From<std::sync::PoisonError<T>> for Error {
     fn from(_: std::sync::PoisonError<T>) -> Self {
-        Self::PoisonedLockError
+        Self::InvalidPoisonedLock()
     }
 }
 
-impl From<ParseIntError> for Error {
-    fn from(_: ParseIntError) -> Self {
-        // this is used for parsing integers from the a packet string
-        Self::InvalidPacket
+impl<T: Into<Error>> From<Option<T>> for Error {
+    fn from(error: Option<T>) -> Self {
+        error.into()
+    }
+}
+
+impl From<Error> for std::io::Error {
+    fn from(err: Error) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::Other, err)
     }
 }
 
@@ -73,9 +90,6 @@ mod tests {
     fn test_error_conversion() {
         let mutex = Mutex::new(0);
         let _poison_error = Error::from(PoisonError::new(mutex.lock()));
-        assert!(matches!(Error::PoisonedLockError, _poison_error));
-
-        let _parse_int_error = Error::from("no int".parse::<i32>().expect_err("unreachable"));
-        assert!(matches!(Error::InvalidPacket, _parse_int_error));
+        assert!(matches!(Error::InvalidPoisonedLock(), _poison_error));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ use websocket::{client::ParseError, WebSocketError};
 /// Enumeration of all possible errors in the `socket.io` context.
 #[derive(Error, Debug)]
 #[non_exhaustive]
+#[cfg_attr(tarpaulin, ignore)]
 pub enum Error {
     // Conform to https://rust-lang.github.io/api-guidelines/naming.html#names-use-a-consistent-word-order-c-word-order
     // Negative verb-object

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,7 @@ pub enum Error {
     #[error("Invalid Url: {0}")]
     InvalidUrl(String),
     #[error("Error during connection via http: {0}")]
-    IncompleteResponceFromReqwest(#[from] ReqwestError),
+    IncompleteResponseFromReqwest(#[from] ReqwestError),
     #[error("Network request returned with status code: {0}")]
     IncompleteHttp(u16),
     #[error("Got illegal handshake response: {0}")]
@@ -47,7 +47,7 @@ pub enum Error {
     #[error("A lock was poisoned")]
     InvalidPoisonedLock(),
     #[error("Got a websocket error: {0}")]
-    IncompleteResponceFromWebsocket(#[from] WebSocketError),
+    IncompleteResponseFromWebsocket(#[from] WebSocketError),
     #[error("Error while parsing the url for the websocket connection: {0}")]
     InvalidWebsocketURL(#[from] ParseError),
     #[error("Got an IO-Error: {0}")]

--- a/src/socketio/packet.rs
+++ b/src/socketio/packet.rs
@@ -121,12 +121,12 @@ impl Packet {
     /// send in another packet.
     pub fn decode_bytes<'a>(payload: &'a Bytes) -> Result<Self> {
         let mut i = 0;
-        let packet_id = u8_to_packet_id(*payload.first().ok_or(Error::EmptyPacket)?)?;
+        let packet_id = u8_to_packet_id(*payload.first().ok_or(Error::EmptyPacket())?)?;
 
         let attachments = if let PacketId::BinaryAck | PacketId::BinaryEvent = packet_id {
             let start = i + 1;
 
-            while payload.get(i).ok_or(Error::IncompletePacket)? != &b'-' && i < payload.len() {
+            while payload.get(i).ok_or(Error::IncompletePacket())? != &b'-' && i < payload.len() {
                 i += 1;
             }
             Some(
@@ -142,15 +142,15 @@ impl Packet {
             None
         };
 
-        let nsp: &'a str = if payload.get(i + 1).ok_or(Error::IncompletePacket)? == &b'/' {
+        let nsp: &'a str = if payload.get(i + 1).ok_or(Error::IncompletePacket())? == &b'/' {
             let mut start = i + 1;
-            while payload.get(i).ok_or(Error::IncompletePacket)? != &b',' && i < payload.len() {
+            while payload.get(i).ok_or(Error::IncompletePacket())? != &b',' && i < payload.len() {
                 i += 1;
             }
             let len = i - start;
             payload
                 .read_with(&mut start, Str::Len(len))
-                .map_err(|_| Error::IncompletePacket)?
+                .map_err(|_| Error::IncompletePacket())?
         } else {
             "/"
         };
@@ -159,7 +159,7 @@ impl Packet {
         let id = if (*next as char).is_digit(10) && i < payload.len() {
             let start = i + 1;
             i += 1;
-            while (*payload.get(i).ok_or(Error::IncompletePacket)? as char).is_digit(10)
+            while (*payload.get(i).ok_or(Error::IncompletePacket())? as char).is_digit(10)
                 && i < payload.len()
             {
                 i += 1;

--- a/src/socketio/transport.rs
+++ b/src/socketio/transport.rs
@@ -119,7 +119,7 @@ impl TransportClient {
     /// in the underlying engine.io transport to get closed as well.
     pub fn disconnect(&mut self) -> Result<()> {
         if !self.is_engineio_connected()? || !self.connected.load(Ordering::Acquire) {
-            return Err(Error::IllegalActionAfterOpen);
+            return Err(Error::IllegalActionAfterOpen());
         }
 
         let disconnect_packet = SocketPacket::new(
@@ -143,7 +143,7 @@ impl TransportClient {
     /// Sends a `socket.io` packet to the server using the `engine.io` client.
     pub fn send(&self, packet: &SocketPacket) -> Result<()> {
         if !self.is_engineio_connected()? || !self.connected.load(Ordering::Acquire) {
-            return Err(Error::IllegalActionAfterOpen);
+            return Err(Error::IllegalActionAfterOpen());
         }
 
         // the packet, encoded as an engine.io message packet
@@ -158,7 +158,7 @@ impl TransportClient {
     /// `attachments` field.
     fn send_binary_attachment(&self, attachment: Bytes) -> Result<()> {
         if !self.is_engineio_connected()? || !self.connected.load(Ordering::Acquire) {
-            return Err(Error::ActionBeforeOpen);
+            return Err(Error::IllegalActionBeforeOpen());
         }
 
         self.engine_socket


### PR DESCRIPTION
Renamed error types to conform to https://rust-lang.github.io/api-guidelines/naming.html#names-use-a-consistent-word-order-c-word-order