### PR TITLE
Main cache cargo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Build
         run: cargo build --verbose
       - name: Linting

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,6 +30,19 @@ jobs:
           cd ci && docker build -t test_suite:latest .
           docker run -d --name test_suite -p 4200:4200 -p 4201:4201 -p 4202:4202 test_suite:latest
 
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo-tarpaulin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run testsuite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,18 @@ jobs:
           cd ci && docker build -t test_suite:latest .
           docker run -d -p 4200:4200 -p 4201:4201 -p 4202:4202 test_suite:latest
 
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run testsuite
         run: cargo test --verbose 


### PR DESCRIPTION
Cache build dependencies to cut down on CI time. Presently takes ~5min to run tests. Should this target refactoring or master?

References:
- https://dev.to/github/caching-dependencies-to-speed-up-workflows-in-github-actions-3efl
- https://github.com/actions/cache/blob/main/examples.md#rust---cargo
- Cherry picked from https://github.com/1c3t3a/rust-socketio/pull/69