### PR TITLE
feat: remove sleep from websocket

### DIFF
--- a/src/engineio/transports/websocket.rs
+++ b/src/engineio/transports/websocket.rs
@@ -54,8 +54,6 @@ impl WebsocketTransport {
             Packet::new(PacketId::Ping, Bytes::from("probe")),
         ))?)))?;
 
-        std::thread::sleep(std::time::Duration::from_secs(10));
-
         // expect to receive a probe packet
         let message = receiver.recv_message()?;
         if message.take_payload() != Bytes::from(Packet::new(PacketId::Pong, Bytes::from("probe")))

--- a/src/socketio/transport.rs
+++ b/src/socketio/transport.rs
@@ -12,8 +12,8 @@ use bytes::Bytes;
 use native_tls::TlsConnector;
 use rand::{thread_rng, Rng};
 use reqwest::header::HeaderMap;
-use std::thread;
 use std::convert::TryFrom;
+use std::thread;
 use std::{
     fmt::Debug,
     sync::{atomic::Ordering, RwLock},


### PR DESCRIPTION
The sleep was for debug purposes it should not be in repo.