### PR TITLE
0.2.X deprecation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,7 @@ pub enum Error {
     #[error("Did not receive an ack for id: {0}")]
     DidNotReceiveProperAck(i32),
     #[error("An illegal action (such as setting a callback after being connected) was triggered")]
+    #[deprecated(note = "Error removed in 0.3.0")]
     IllegalActionAfterOpen,
     #[error("Specified namespace {0} is not valid")]
     IllegalNamespace(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ impl SocketBuilder {
 
     /// Sets the target namespace of the client. The namespace must start
     /// with a leading `/`. Valid examples are e.g. `/admin`, `/foo`.
-    #[deprecated(note = "use namespace instead")]
+     #[deprecated(note = "use namespace(nsp) instead")]
     pub fn set_namespace<T: Into<String>>(mut self, namespace: T) -> Result<Self> {
         let nsp = namespace.into();
         if !nsp.starts_with('/') {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ impl SocketBuilder {
 
     /// Sets the target namespace of the client. The namespace must start
     /// with a leading `/`. Valid examples are e.g. `/admin`, `/foo`.
-     #[deprecated(note = "use namespace(nsp) instead")]
+    #[deprecated(note = "use namespace(nsp) instead")]
     pub fn set_namespace<T: Into<String>>(mut self, namespace: T) -> Result<Self> {
         let nsp = namespace.into();
         if !nsp.starts_with('/') {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,7 @@ impl SocketBuilder {
 
     /// Sets the target namespace of the client. The namespace must start
     /// with a leading `/`. Valid examples are e.g. `/admin`, `/foo`.
+    #[deprecated(note = "use namespace instead")]
     pub fn set_namespace<T: Into<String>>(mut self, namespace: T) -> Result<Self> {
         let nsp = namespace.into();
         if !nsp.starts_with('/') {
@@ -184,6 +185,13 @@ impl SocketBuilder {
         }
         self.namespace = Some(nsp);
         Ok(self)
+    }
+
+    /// Sets the target namespace of the client. The namespace must start
+    /// with a leading `/`. Valid examples are e.g. `/admin`, `/foo`.
+    #[allow(deprecated)]
+    pub fn namespace<T: Into<String>>(mut self, namespace: T) -> Result<Self> {
+        self.set_namespace(namespace)
     }
 
     /// Registers a new callback for a certain [`socketio::event::Event`]. The event could either be
@@ -239,8 +247,66 @@ impl SocketBuilder {
     ///     .connect();
     ///
     /// ```
+    #[deprecated(note = "use tls_config instead")]
     pub fn set_tls_config(mut self, tls_config: TlsConnector) -> Self {
         self.tls_config = Some(tls_config);
+        self
+    }
+
+    /// Uses a preconfigured TLS connector for secure cummunication. This configures
+    /// both the `polling` as well as the `websocket` transport type.
+    /// # Example
+    /// ```rust
+    /// use rust_socketio::{SocketBuilder, Payload};
+    /// use native_tls::TlsConnector;
+    ///
+    /// let tls_connector =  TlsConnector::builder()
+    ///            .use_sni(true)
+    ///            .build()
+    ///            .expect("Found illegal configuration");
+    ///
+    /// let socket = SocketBuilder::new("http://localhost:4200")
+    ///     .set_namespace("/admin")
+    ///     .expect("illegal namespace")
+    ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))
+    ///     .set_tls_config(tls_connector)
+    ///     .connect();
+    ///
+    /// ```
+    #[allow(deprecated)]
+    pub fn tls_config(self, tls_config: TlsConnector) -> Self {
+        self.set_tls_config(tls_config)
+    }
+
+    /// Sets custom http headers for the opening request. The headers will be passed to the underlying
+    /// transport type (either websockets or polling) and then get passed with every request thats made.
+    /// via the transport layer.
+    /// # Example
+    /// ```rust
+    /// use rust_socketio::{SocketBuilder, Payload};
+    /// use reqwest::header::{ACCEPT_ENCODING};
+    ///
+    ///
+    /// let socket = SocketBuilder::new("http://localhost:4200")
+    ///     .set_namespace("/admin")
+    ///     .expect("illegal namespace")
+    ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))
+    ///     .set_opening_header(ACCEPT_ENCODING, "application/json".parse().unwrap())
+    ///     .connect();
+    ///
+    /// ```
+    #[deprecated(note = "use opening_header instead")]
+    pub fn set_opening_header<K: IntoHeaderName>(mut self, key: K, val: HeaderValue) -> Self {
+        match self.opening_headers {
+            Some(ref mut map) => {
+                map.insert(key, val);
+            }
+            None => {
+                let mut map = HeaderMap::new();
+                map.insert(key, val);
+                self.opening_headers = Some(map);
+            }
+        }
         self
     }
 
@@ -261,18 +327,9 @@ impl SocketBuilder {
     ///     .connect();
     ///
     /// ```
-    pub fn set_opening_header<K: IntoHeaderName>(mut self, key: K, val: HeaderValue) -> Self {
-        match self.opening_headers {
-            Some(ref mut map) => {
-                map.insert(key, val);
-            }
-            None => {
-                let mut map = HeaderMap::new();
-                map.insert(key, val);
-                self.opening_headers = Some(map);
-            }
-        }
-        self
+    #[allow(deprecated)]
+    pub fn opening_header<K: IntoHeaderName>(self, key: K, val: HeaderValue) -> Self {
+        self.set_opening_header(key, val)
     }
 
     /// Connects the socket to a certain endpoint. This returns a connected

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ impl SocketBuilder {
     ///     .connect();
     ///
     /// ```
-    #[deprecated(note = "use tls_config instead")]
+    #[deprecated(note = "use tls_config(tls_config) instead")]
     pub fn set_tls_config(mut self, tls_config: TlsConnector) -> Self {
         self.tls_config = Some(tls_config);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,7 @@ impl SocketBuilder {
     ///     .connect();
     ///
     /// ```
-    #[deprecated(note = "use opening_header instead")]
+    #[deprecated(note = "use opening_header(key, value) instead")]
     pub fn set_opening_header<K: IntoHeaderName>(mut self, key: K, val: HeaderValue) -> Self {
         match self.opening_headers {
             Some(ref mut map) => {

--- a/src/socketio/packet.rs
+++ b/src/socketio/packet.rs
@@ -21,8 +21,12 @@ pub struct Packet {
     pub packet_type: PacketId,
     pub nsp: String,
     pub data: Option<String>,
+    #[deprecated(
+        note = "This will be the 0th element in attachments (attachments: Vec<Bytes>) in 0.3.0"
+    )]
     pub binary_data: Option<Bytes>,
     pub id: Option<i32>,
+    #[deprecated(note = "This will be attachment_count (attachment_count: u8) in 0.3.0")]
     pub attachments: Option<u8>,
 }
 

--- a/src/socketio/transport.rs
+++ b/src/socketio/transport.rs
@@ -76,6 +76,7 @@ impl TransportClient {
     }
 
     /// Registers a new event with some callback function `F`.
+    #[deprecated(note = "Register callbacks in builder instead")]
     pub fn on<F>(&mut self, event: Event, callback: Box<F>) -> Result<()>
     where
         F: FnMut(Payload, Socket) + 'static + Sync + Send,


### PR DESCRIPTION
This will be the final update to 0.2.X before 0.3.0 goes live. Uses deprecation notes to walk the user through how to upgrade from 0.2.X to 0.3.0. AKA if the users resolve all deprecation warnings described in the notes they can upgrade to 0.3.0 without errors. (even without looking at the changelog)