### PR TITLE
refactor: move callback init to builder

### DIFF
--- a/engineio/src/callback.rs
+++ b/engineio/src/callback.rs
@@ -1,0 +1,89 @@
+use crate::Packet;
+use bytes::Bytes;
+use std::fmt::Debug;
+use std::ops::Deref;
+use std::sync::Arc;
+
+pub(crate) type Callback<I> = dyn Fn(I) + 'static + Sync + Send;
+
+#[derive(Clone)]
+/// Internal type, only implements debug on fixed set of generics
+pub(crate) struct OptionalCallback<I> {
+    inner: Arc<Option<Box<Callback<I>>>>,
+}
+
+impl<I> OptionalCallback<I> {
+    pub(crate) fn new<T>(callback: T) -> Self
+    where
+        T: Fn(I) + 'static + Sync + Send,
+    {
+        OptionalCallback {
+            inner: Arc::new(Some(Box::new(callback))),
+        }
+    }
+
+    pub(crate) fn default() -> Self {
+        OptionalCallback {
+            inner: Arc::new(None),
+        }
+    }
+}
+
+impl Debug for OptionalCallback<String> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        f.write_fmt(format_args!(
+            "Callback({:?})",
+            if self.inner.is_some() {
+                "Fn(String)"
+            } else {
+                "None"
+            }
+        ))
+    }
+}
+
+impl Debug for OptionalCallback<()> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        f.write_fmt(format_args!(
+            "Callback({:?})",
+            if self.inner.is_some() {
+                "Fn(())"
+            } else {
+                "None"
+            }
+        ))
+    }
+}
+
+impl Debug for OptionalCallback<Packet> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        f.write_fmt(format_args!(
+            "Callback({:?})",
+            if self.inner.is_some() {
+                "Fn(Packet)"
+            } else {
+                "None"
+            }
+        ))
+    }
+}
+
+impl Debug for OptionalCallback<Bytes> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        f.write_fmt(format_args!(
+            "Callback({:?})",
+            if self.inner.is_some() {
+                "Fn(Bytes)"
+            } else {
+                "None"
+            }
+        ))
+    }
+}
+
+impl<I> Deref for OptionalCallback<I> {
+    type Target = Option<Box<Callback<I>>>;
+    fn deref(&self) -> &<Self as std::ops::Deref>::Target {
+        self.inner.as_ref()
+    }
+}

--- a/engineio/src/client/socket.rs
+++ b/engineio/src/client/socket.rs
@@ -110,7 +110,7 @@ impl SocketBuilder {
         self
     }
 
-    /// Preforms the handshake
+    /// Performs the handshake
     fn handshake_with_transport<T: Transport>(&mut self, transport: &T) -> Result<()> {
         // No need to handshake twice
         if self.handshake.is_some() {

--- a/engineio/src/client/socket.rs
+++ b/engineio/src/client/socket.rs
@@ -1,4 +1,5 @@
 use super::super::socket::Socket as InnerSocket;
+use crate::callback::OptionalCallback;
 use crate::transport::Transport;
 
 use crate::error::{Error, Result};
@@ -23,6 +24,11 @@ pub struct SocketBuilder {
     tls_config: Option<TlsConnector>,
     headers: Option<HeaderMap>,
     handshake: Option<HandshakePacket>,
+    on_error: OptionalCallback<String>,
+    on_open: OptionalCallback<()>,
+    on_close: OptionalCallback<()>,
+    on_data: OptionalCallback<Bytes>,
+    on_packet: OptionalCallback<Packet>,
 }
 
 impl SocketBuilder {
@@ -39,19 +45,72 @@ impl SocketBuilder {
             headers: None,
             tls_config: None,
             handshake: None,
+            on_close: OptionalCallback::default(),
+            on_data: OptionalCallback::default(),
+            on_error: OptionalCallback::default(),
+            on_open: OptionalCallback::default(),
+            on_packet: OptionalCallback::default(),
         }
     }
 
+    /// Specify transport's tls config
     pub fn tls_config(mut self, tls_config: TlsConnector) -> Self {
         self.tls_config = Some(tls_config);
         self
     }
 
+    /// Specify transport's HTTP headers
     pub fn headers(mut self, headers: HeaderMap) -> Self {
         self.headers = Some(headers);
         self
     }
 
+    /// Registers the `on_close` callback.
+    pub fn on_close<T>(mut self, callback: T) -> Self
+    where
+        T: Fn(()) + 'static + Sync + Send,
+    {
+        self.on_close = OptionalCallback::new(callback);
+        self
+    }
+
+    /// Registers the `on_data` callback.
+    pub fn on_data<T>(mut self, callback: T) -> Self
+    where
+        T: Fn(Bytes) + 'static + Sync + Send,
+    {
+        self.on_data = OptionalCallback::new(callback);
+        self
+    }
+
+    /// Registers the `on_error` callback.
+    pub fn on_error<T>(mut self, callback: T) -> Self
+    where
+        T: Fn(String) + 'static + Sync + Send,
+    {
+        self.on_error = OptionalCallback::new(callback);
+        self
+    }
+
+    /// Registers the `on_open` callback.
+    pub fn on_open<T>(mut self, callback: T) -> Self
+    where
+        T: Fn(()) + 'static + Sync + Send,
+    {
+        self.on_open = OptionalCallback::new(callback);
+        self
+    }
+
+    /// Registers the `on_packet` callback.
+    pub fn on_packet<T>(mut self, callback: T) -> Self
+    where
+        T: Fn(Packet) + 'static + Sync + Send,
+    {
+        self.on_packet = OptionalCallback::new(callback);
+        self
+    }
+
+    /// Preforms the handshake
     fn handshake_with_transport<T: Transport>(&mut self, transport: &T) -> Result<()> {
         // No need to handshake twice
         if self.handshake.is_some() {
@@ -114,7 +173,15 @@ impl SocketBuilder {
 
         // SAFETY: handshake function called previously.
         Ok(Socket {
-            socket: InnerSocket::new(transport.into(), self.handshake.unwrap()),
+            socket: InnerSocket::new(
+                transport.into(),
+                self.handshake.unwrap(),
+                self.on_close,
+                self.on_data,
+                self.on_error,
+                self.on_open,
+                self.on_packet,
+            ),
         })
     }
 
@@ -149,7 +216,15 @@ impl SocketBuilder {
             // NOTE: Although self.url contains the sid, it does not propagate to the transport
             // SAFETY: handshake function called previously.
             Ok(Socket {
-                socket: InnerSocket::new(transport.into(), self.handshake.unwrap()),
+                socket: InnerSocket::new(
+                    transport.into(),
+                    self.handshake.unwrap(),
+                    self.on_close,
+                    self.on_data,
+                    self.on_error,
+                    self.on_open,
+                    self.on_packet,
+                ),
             })
         } else if url.scheme() == "https" {
             let transport = WebsocketSecureTransport::new(
@@ -165,7 +240,15 @@ impl SocketBuilder {
             // NOTE: Although self.url contains the sid, it does not propagate to the transport
             // SAFETY: handshake function called previously.
             Ok(Socket {
-                socket: InnerSocket::new(transport.into(), self.handshake.unwrap()),
+                socket: InnerSocket::new(
+                    transport.into(),
+                    self.handshake.unwrap(),
+                    self.on_close,
+                    self.on_data,
+                    self.on_error,
+                    self.on_open,
+                    self.on_packet,
+                ),
             })
         } else {
             Err(Error::InvalidUrlScheme(url.scheme().to_string()))
@@ -197,46 +280,6 @@ impl SocketBuilder {
 }
 
 impl Socket {
-    /// Registers the `on_open` callback.
-    pub fn on_open<F>(&mut self, function: F) -> Result<()>
-    where
-        F: Fn(()) + 'static + Sync + Send,
-    {
-        self.socket.on_open(function)
-    }
-
-    /// Registers the `on_error` callback.
-    pub fn on_error<F>(&mut self, function: F) -> Result<()>
-    where
-        F: Fn(String) + 'static + Sync + Send,
-    {
-        self.socket.on_error(function)
-    }
-
-    /// Registers the `on_packet` callback.
-    pub fn on_packet<F>(&mut self, function: F) -> Result<()>
-    where
-        F: Fn(Packet) + 'static + Sync + Send,
-    {
-        self.socket.on_packet(function)
-    }
-
-    /// Registers the `on_data` callback.
-    pub fn on_data<F>(&mut self, function: F) -> Result<()>
-    where
-        F: Fn(Bytes) + 'static + Sync + Send,
-    {
-        self.socket.on_data(function)
-    }
-
-    /// Registers the `on_close` callback.
-    pub fn on_close<F>(&mut self, function: F) -> Result<()>
-    where
-        F: Fn(()) + 'static + Sync + Send,
-    {
-        self.socket.on_close(function)
-    }
-
     pub fn close(&mut self) -> Result<()> {
         self.socket.close()
     }
@@ -308,7 +351,7 @@ impl Socket {
 
     pub fn iter(&self) -> Iter {
         Iter {
-            socket: &self,
+            socket: self,
             iter: None,
         }
     }
@@ -353,7 +396,7 @@ mod test {
     #[test]
     fn test_illegal_actions() -> Result<()> {
         let url = crate::test::engine_io_server()?;
-        let mut sut = SocketBuilder::new(url.clone()).build()?;
+        let sut = builder(url.clone()).build()?;
 
         assert!(sut
             .emit(Packet::new(PacketId::Close, Bytes::new()))
@@ -361,15 +404,9 @@ mod test {
 
         sut.connect()?;
 
-        assert!(sut.on_open(|_| {}).is_err());
-        assert!(sut.on_close(|_| {}).is_err());
-        assert!(sut.on_packet(|_| {}).is_err());
-        assert!(sut.on_data(|_| {}).is_err());
-        assert!(sut.on_error(|_| {}).is_err());
-
         assert!(sut.poll().is_ok());
 
-        let sut = SocketBuilder::new(url).build()?;
+        let sut = builder(url).build()?;
         assert!(sut.poll().is_err());
 
         Ok(())
@@ -378,28 +415,28 @@ mod test {
 
     use crate::packet::Packet;
 
+    fn builder(url: Url) -> SocketBuilder {
+        // TODO: confirm callbacks are getting data
+        SocketBuilder::new(url)
+            .on_open(|_| {
+                println!("Open event!");
+            })
+            .on_packet(|packet| {
+                println!("Received packet: {:?}", packet);
+            })
+            .on_data(|data| {
+                println!("Received data: {:?}", std::str::from_utf8(&data));
+            })
+            .on_close(|_| {
+                println!("Close event!");
+            })
+            .on_error(|error| {
+                println!("Error {}", error);
+            })
+    }
+
     fn test_connection(socket: Socket) -> Result<()> {
         let mut socket = socket;
-        // TODO: confirm callbacks are getting data
-        socket.on_open(|_| {
-            println!("Open event!");
-        })?;
-
-        socket.on_packet(|packet| {
-            println!("Received packet: {:?}", packet);
-        })?;
-
-        socket.on_data(|data| {
-            println!("Received data: {:?}", std::str::from_utf8(&data));
-        })?;
-
-        socket.on_close(|_| {
-            println!("Close event!");
-        })?;
-
-        socket.on_error(|error| {
-            println!("Error {}", error);
-        })?;
 
         socket.connect().unwrap();
 
@@ -426,14 +463,14 @@ mod test {
     #[test]
     fn test_connection_dynamic() -> Result<()> {
         let url = crate::test::engine_io_server()?;
-        let socket = SocketBuilder::new(url).build()?;
+        let socket = builder(url).build()?;
         test_connection(socket)
     }
 
     #[test]
     fn test_connection_dynamic_secure() -> Result<()> {
         let url = crate::test::engine_io_server_secure()?;
-        let mut builder = SocketBuilder::new(url);
+        let mut builder = builder(url);
         builder = builder.tls_config(crate::test::tls_connector()?);
         let socket = builder.build()?;
         test_connection(socket)
@@ -442,7 +479,7 @@ mod test {
     #[test]
     fn test_connection_polling() -> Result<()> {
         let url = crate::test::engine_io_server()?;
-        let socket = SocketBuilder::new(url).build_polling()?;
+        let socket = builder(url).build_polling()?;
         test_connection(socket)
     }
 
@@ -454,7 +491,7 @@ mod test {
 
         let mut headers = HeaderMap::new();
         headers.insert(HOST, host);
-        let mut builder = SocketBuilder::new(url);
+        let mut builder = builder(url);
 
         builder = builder.tls_config(crate::test::tls_connector()?);
         builder = builder.headers(headers);
@@ -471,7 +508,7 @@ mod test {
     fn test_connection_ws() -> Result<()> {
         let url = crate::test::engine_io_server()?;
 
-        let builder = SocketBuilder::new(url);
+        let builder = builder(url);
         let socket = builder.clone().build_websocket()?;
         test_connection(socket)?;
 
@@ -484,14 +521,14 @@ mod test {
         let url = crate::test::engine_io_server()?;
         let illegal_url = "this is illegal";
 
-        assert!(Url::parse(&illegal_url).is_err());
+        assert!(Url::parse(illegal_url).is_err());
 
         let invalid_protocol = "file:///tmp/foo";
-        assert!(SocketBuilder::new(Url::parse(&invalid_protocol).unwrap())
+        assert!(builder(Url::parse(invalid_protocol).unwrap())
             .build()
             .is_err());
 
-        let sut = SocketBuilder::new(url.clone()).build()?;
+        let sut = builder(url.clone()).build()?;
         let _error = sut
             .emit(Packet::new(PacketId::Close, Bytes::new()))
             .expect_err("error");
@@ -503,7 +540,7 @@ mod test {
             std::env::var("ENGINE_IO_SECURE_HOST").unwrap_or_else(|_| "localhost".to_owned());
         headers.insert(HOST, host);
 
-        let _ = SocketBuilder::new(url.clone())
+        let _ = builder(url.clone())
             .tls_config(
                 TlsConnector::builder()
                     .danger_accept_invalid_certs(true)
@@ -511,7 +548,7 @@ mod test {
                     .unwrap(),
             )
             .build()?;
-        let _ = SocketBuilder::new(url).headers(headers).build()?;
+        let _ = builder(url).headers(headers).build()?;
         Ok(())
     }
 }

--- a/engineio/src/error.rs
+++ b/engineio/src/error.rs
@@ -38,9 +38,6 @@ pub enum Error {
     IllegalActionBeforeOpen(),
     #[error("string is not json serializable: {0}")]
     InvalidJson(#[from] JsonError),
-    #[error("An illegal action (such as setting a callback after being connected) was triggered")]
-    //TODO: make these impossible by using builders and immutable data.
-    IllegalActionAfterOpen(),
     #[error("A lock was poisoned")]
     InvalidPoisonedLock(),
     #[error("Got a websocket error: {0}")]

--- a/engineio/src/lib.rs
+++ b/engineio/src/lib.rs
@@ -49,7 +49,7 @@ macro_rules! spawn_scoped {
         .unwrap();
     };
 }
-
+mod callback;
 pub mod client;
 /// Generic header map
 pub mod header;

--- a/engineio/src/packet.rs
+++ b/engineio/src/packet.rs
@@ -156,11 +156,6 @@ impl Payload {
     const SEPARATOR: char = '\x1e';
 
     #[cfg(test)]
-    pub fn new(packets: Vec<Packet>) -> Self {
-        Payload(packets)
-    }
-
-    #[cfg(test)]
     pub fn len(&self) -> usize {
         self.0.len()
     }

--- a/engineio/src/socket.rs
+++ b/engineio/src/socket.rs
@@ -1,3 +1,4 @@
+use crate::callback::OptionalCallback;
 use crate::transport::TransportType;
 
 use crate::error::{Error, Result};
@@ -6,114 +7,48 @@ use bytes::Bytes;
 use std::convert::TryFrom;
 use std::{fmt::Debug, sync::atomic::Ordering};
 use std::{
-    sync::{atomic::AtomicBool, Arc, Mutex, RwLock},
+    sync::{atomic::AtomicBool, Arc, Mutex},
     time::Instant,
 };
-
-/// Type of a `Callback` function. (Normal closures can be passed in here).
-type Callback<I> = Arc<RwLock<Option<Box<dyn Fn(I) + 'static + Sync + Send>>>>;
 
 /// An `engine.io` socket which manages a connection with the server and allows
 /// it to register common callbacks.
 #[derive(Clone)]
 pub struct Socket {
     transport: Arc<TransportType>,
-    //TODO: Store these in a map
-    pub on_error: Callback<String>,
-    pub on_open: Callback<()>,
-    pub on_close: Callback<()>,
-    pub on_data: Callback<Bytes>,
-    pub on_packet: Callback<Packet>,
-    pub connected: Arc<AtomicBool>,
+    on_close: OptionalCallback<()>,
+    on_data: OptionalCallback<Bytes>,
+    on_error: OptionalCallback<String>,
+    on_open: OptionalCallback<()>,
+    on_packet: OptionalCallback<Packet>,
+    connected: Arc<AtomicBool>,
     last_ping: Arc<Mutex<Instant>>,
     last_pong: Arc<Mutex<Instant>>,
     connection_data: Arc<HandshakePacket>,
 }
 
 impl Socket {
-    pub(crate) fn new(transport: TransportType, handshake: HandshakePacket) -> Self {
+    pub(crate) fn new(
+        transport: TransportType,
+        handshake: HandshakePacket,
+        on_close: OptionalCallback<()>,
+        on_data: OptionalCallback<Bytes>,
+        on_error: OptionalCallback<String>,
+        on_open: OptionalCallback<()>,
+        on_packet: OptionalCallback<Packet>,
+    ) -> Self {
         Socket {
-            on_error: Arc::new(RwLock::new(None)),
-            on_open: Arc::new(RwLock::new(None)),
-            on_close: Arc::new(RwLock::new(None)),
-            on_data: Arc::new(RwLock::new(None)),
-            on_packet: Arc::new(RwLock::new(None)),
+            on_close,
+            on_data,
+            on_error,
+            on_open,
+            on_packet,
             transport: Arc::new(transport),
             connected: Arc::new(AtomicBool::default()),
             last_ping: Arc::new(Mutex::new(Instant::now())),
             last_pong: Arc::new(Mutex::new(Instant::now())),
             connection_data: Arc::new(handshake),
         }
-    }
-
-    /// Registers the `on_open` callback.
-    pub fn on_open<F>(&mut self, function: F) -> Result<()>
-    where
-        F: Fn(()) + 'static + Sync + Send,
-    {
-        if self.is_connected()? {
-            return Err(Error::IllegalActionAfterOpen());
-        }
-        let mut on_open = self.on_open.write()?;
-        *on_open = Some(Box::new(function));
-        drop(on_open);
-        Ok(())
-    }
-
-    /// Registers the `on_error` callback.
-    pub fn on_error<F>(&mut self, function: F) -> Result<()>
-    where
-        F: Fn(String) + 'static + Sync + Send,
-    {
-        if self.is_connected()? {
-            return Err(Error::IllegalActionAfterOpen());
-        }
-        let mut on_error = self.on_error.write()?;
-        *on_error = Some(Box::new(function));
-        drop(on_error);
-        Ok(())
-    }
-
-    /// Registers the `on_packet` callback.
-    pub fn on_packet<F>(&mut self, function: F) -> Result<()>
-    where
-        F: Fn(Packet) + 'static + Sync + Send,
-    {
-        if self.is_connected()? {
-            return Err(Error::IllegalActionAfterOpen());
-        }
-        let mut on_packet = self.on_packet.write()?;
-        *on_packet = Some(Box::new(function));
-        drop(on_packet);
-        Ok(())
-    }
-
-    /// Registers the `on_data` callback.
-    pub fn on_data<F>(&mut self, function: F) -> Result<()>
-    where
-        F: Fn(Bytes) + 'static + Sync + Send,
-    {
-        if self.is_connected()? {
-            return Err(Error::IllegalActionAfterOpen());
-        }
-        let mut on_data = self.on_data.write()?;
-        *on_data = Some(Box::new(function));
-        drop(on_data);
-        Ok(())
-    }
-
-    /// Registers the `on_close` callback.
-    pub fn on_close<F>(&mut self, function: F) -> Result<()>
-    where
-        F: Fn(()) + 'static + Sync + Send,
-    {
-        if self.is_connected()? {
-            return Err(Error::IllegalActionAfterOpen());
-        }
-        let mut on_close = self.on_close.write()?;
-        *on_close = Some(Box::new(function));
-        drop(on_close);
-        Ok(())
     }
 
     pub fn close(&self) -> Result<()> {
@@ -128,7 +63,7 @@ impl Socket {
         // SAFETY: Has valid handshake due to type
         self.connected.store(true, Ordering::Release);
 
-        if let Some(on_open) = self.on_open.read()?.as_ref() {
+        if let Some(on_open) = self.on_open.as_ref() {
             spawn_scoped!(on_open(()));
         }
 
@@ -185,12 +120,9 @@ impl Socket {
     /// Calls the error callback with a given message.
     #[inline]
     fn call_error_callback(&self, text: String) -> Result<()> {
-        let function = self.on_error.read()?;
-        if let Some(function) = function.as_ref() {
+        if let Some(function) = self.on_error.as_ref() {
             spawn_scoped!(function(text));
         }
-        drop(function);
-
         Ok(())
     }
 
@@ -205,21 +137,21 @@ impl Socket {
     }
 
     pub(crate) fn handle_packet(&self, packet: Packet) -> Result<()> {
-        if let Some(on_packet) = self.on_packet.read()?.as_ref() {
+        if let Some(on_packet) = self.on_packet.as_ref() {
             spawn_scoped!(on_packet(packet));
         }
         Ok(())
     }
 
     pub(crate) fn handle_data(&self, data: Bytes) -> Result<()> {
-        if let Some(on_data) = self.on_data.read()?.as_ref() {
+        if let Some(on_data) = self.on_data.as_ref() {
             spawn_scoped!(on_data(data));
         }
         Ok(())
     }
 
     pub(crate) fn handle_close(&self) -> Result<()> {
-        if let Some(on_close) = self.on_close.read()?.as_ref() {
+        if let Some(on_close) = self.on_close.as_ref() {
             spawn_scoped!(on_close(()));
         }
         Ok(())
@@ -231,31 +163,11 @@ impl Debug for Socket {
         f.write_fmt(format_args!(
             "EngineSocket(transport: {:?}, on_error: {:?}, on_open: {:?}, on_close: {:?}, on_packet: {:?}, on_data: {:?}, connected: {:?}, last_ping: {:?}, last_pong: {:?}, connection_data: {:?})",
             self.transport,
-            if self.on_error.read().unwrap().is_some() {
-                "Fn(String)"
-            } else {
-                "None"
-            },
-            if self.on_open.read().unwrap().is_some() {
-                "Fn(())"
-            } else {
-                "None"
-            },
-            if self.on_close.read().unwrap().is_some() {
-                "Fn(())"
-            } else {
-                "None"
-            },
-            if self.on_packet.read().unwrap().is_some() {
-                "Fn(Packet)"
-            } else {
-                "None"
-            },
-            if self.on_data.read().unwrap().is_some() {
-                "Fn(Bytes)"
-            } else {
-                "None"
-            },
+            self.on_error,
+            self.on_open,
+            self.on_close,
+            self.on_packet,
+            self.on_data,
             self.connected,
             self.last_ping,
             self.last_pong,

--- a/socketio/src/client/socket.rs
+++ b/socketio/src/client/socket.rs
@@ -433,10 +433,9 @@ mod test {
         );
         assert!(ack.is_ok());
 
-        socket.disconnect().unwrap();
-        // assert!(socket.disconnect().is_ok());
+        sleep(Duration::from_secs(3));
 
-        sleep(Duration::from_secs(10));
+        assert!(socket.disconnect().is_ok());
 
         Ok(())
     }

--- a/socketio/src/client/socket.rs
+++ b/socketio/src/client/socket.rs
@@ -433,7 +433,7 @@ mod test {
         );
         assert!(ack.is_ok());
 
-        sleep(Duration::from_secs(3));
+        sleep(Duration::from_secs(10));
 
         assert!(socket.disconnect().is_ok());
 

--- a/socketio/src/socket.rs
+++ b/socketio/src/socket.rs
@@ -45,6 +45,7 @@ pub struct Socket {
     engine_socket: Arc<EngineIoSocket>,
     host: Arc<Url>,
     connected: Arc<AtomicBool>,
+    // TODO: Move this to client/socket.rs
     on: Arc<Vec<EventCallback>>,
     outstanding_acks: Arc<RwLock<Vec<Ack>>>,
     // namespace, for multiplexing messages


### PR DESCRIPTION
Refactor to make IllegalActionAfterOpen impossible in engineio. This is not a breaking change thanks to @1c3t3a having the wisdom not to make public yet. Thank you.