### PR TITLE
Devcontainer rust analyzer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,17 @@
         // VS Code don't watch files under ./target
         "files.watcherExclude": {
             "**/target/**": true
-        }
+        }/*,
+        // If you prefer rust-analzyer to be less noisy consider these settings to your settings.json
+        "editor.semanticTokenColorCustomizations": {
+            "rules": {
+                "*.mutable": {
+                    "underline": false
+                }
+            }
+        },
+        "rust-analyzer.inlayHints.parameterHints": false
+        */
     },
 
     // Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,18 +2,19 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/rust
 {
     "name": "Rust",
-    "dockerComposeFile": ["./docker-compose.yaml"],
+    "dockerComposeFile": [
+        "./docker-compose.yaml"
+    ],
     "service": "rust-client",
     "workspaceFolder": "/workspace/rust-socketio",
     "shutdownAction": "stopCompose",
-
     // Set *default* container specific settings.json values on container create.
-    "settings": { 
+    "settings": {
         "lldb.executable": "/usr/bin/lldb",
         // VS Code don't watch files under ./target
         "files.watcherExclude": {
             "**/target/**": true
-        }/*,
+        } /*,
         // If you prefer rust-analzyer to be less noisy consider these settings to your settings.json
         "editor.semanticTokenColorCustomizations": {
             "rules": {
@@ -25,7 +26,6 @@
         "rust-analyzer.inlayHints.parameterHints": false
         */
     },
-
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [
         "matklad.rust-analyzer",
@@ -34,10 +34,8 @@
         "eamodio.gitlens",
         "streetsidesoftware.code-spell-checker"
     ],
-
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
-
     // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,10 +18,9 @@
 
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [
-        "rust-lang.rust",
+        "matklad.rust-analyzer",
         "bungcip.better-toml",
         "vadimcn.vscode-lldb",
-        "mutantdino.resourcemonitor",
         "eamodio.gitlens",
         "streetsidesoftware.code-spell-checker"
     ],


### PR DESCRIPTION
Switched to rust-analyzer per recommendation [here](https://github.com/1c3t3a/rust-socketio/pull/50#discussion_r669493106). Looks like autocomplete is working now (perhaps I didn't wait long enough before? rust-anaylzer's start up time is significantly greater than rls). Also found (and mentioned in a comment) the settings in rust-analyzer to make it less noisy.