### PR TITLE
0.3.0 socketio callbacks in builder

### DIFF
--- a/engineio/src/lib.rs
+++ b/engineio/src/lib.rs
@@ -53,6 +53,7 @@ mod callback;
 pub mod client;
 /// Generic header map
 pub mod header;
+pub mod model;
 pub mod packet;
 pub(self) mod socket;
 pub mod transport;

--- a/engineio/src/model.rs
+++ b/engineio/src/model.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::Packet;
 
-pub trait Socket {
+pub trait Socket: Send + Sync + Clone {
     fn close(&self) -> Result<()>;
     fn connect(&self) -> Result<()>;
     fn emit(&self, packet: Packet) -> Result<()>;

--- a/engineio/src/model.rs
+++ b/engineio/src/model.rs
@@ -1,0 +1,9 @@
+use crate::error::Result;
+use crate::Packet;
+
+pub trait Socket {
+    fn close(&self) -> Result<()>;
+    fn connect(&self) -> Result<()>;
+    fn emit(&self, packet: Packet) -> Result<()>;
+    fn is_connected(&self) -> Result<bool>;
+}

--- a/engineio/src/socket.rs
+++ b/engineio/src/socket.rs
@@ -1,20 +1,22 @@
 use crate::callback::OptionalCallback;
+use crate::model::Socket;
 use crate::transport::TransportType;
 
 use crate::error::{Error, Result};
 use crate::packet::{HandshakePacket, Packet, PacketId, Payload};
 use bytes::Bytes;
 use std::convert::TryFrom;
+use std::sync::RwLock;
 use std::{fmt::Debug, sync::atomic::Ordering};
 use std::{
-    sync::{atomic::AtomicBool, Arc, Mutex},
+    sync::{atomic::AtomicBool, Arc},
     time::Instant,
 };
 
 /// An `engine.io` socket which manages a connection with the server and allows
 /// it to register common callbacks.
 #[derive(Clone)]
-pub struct Socket {
+pub struct InnerSocket {
     transport: Arc<TransportType>,
     on_close: OptionalCallback<()>,
     on_data: OptionalCallback<Bytes>,
@@ -22,22 +24,22 @@ pub struct Socket {
     on_open: OptionalCallback<()>,
     on_packet: OptionalCallback<Packet>,
     connected: Arc<AtomicBool>,
-    last_ping: Arc<Mutex<Instant>>,
-    last_pong: Arc<Mutex<Instant>>,
+    last_heartbeat: Arc<RwLock<Instant>>,
     connection_data: Arc<HandshakePacket>,
 }
 
-impl Socket {
+impl InnerSocket {
     pub(crate) fn new(
         transport: TransportType,
         handshake: HandshakePacket,
+        heartbeat: Instant,
         on_close: OptionalCallback<()>,
         on_data: OptionalCallback<Bytes>,
         on_error: OptionalCallback<String>,
         on_open: OptionalCallback<()>,
         on_packet: OptionalCallback<Packet>,
     ) -> Self {
-        Socket {
+        InnerSocket {
             on_close,
             on_data,
             on_error,
@@ -45,13 +47,90 @@ impl Socket {
             on_packet,
             transport: Arc::new(transport),
             connected: Arc::new(AtomicBool::default()),
-            last_ping: Arc::new(Mutex::new(Instant::now())),
-            last_pong: Arc::new(Mutex::new(Instant::now())),
             connection_data: Arc::new(handshake),
+            last_heartbeat: Arc::new(RwLock::new(heartbeat)),
         }
     }
 
-    pub fn close(&self) -> Result<()> {
+    /// Polls for next payload
+    pub(crate) fn poll(&self) -> Result<Option<Payload>> {
+        if self.connected.load(Ordering::Acquire) {
+            let data = self.transport.as_transport().poll()?;
+
+            if data.is_empty() {
+                return Ok(None);
+            }
+
+            let payload = Payload::try_from(data)?;
+
+            let iter = payload.iter();
+
+            for packet in iter {
+                // check for the appropriate action or callback
+                self.handle_packet(packet.clone())?;
+                match packet.packet_id {
+                    PacketId::MessageBinary => {
+                        self.handle_data(packet.data.clone())?;
+                    }
+                    PacketId::Message => {
+                        self.handle_data(packet.data.clone())?;
+                    }
+                    PacketId::Close => {
+                        self.handle_close()?;
+                        // set current state to not connected and stop polling
+                        self.close()?;
+                    }
+                    PacketId::Open => {
+                        unreachable!("Won't happen as we open the connection beforehand");
+                    }
+                    _ => {
+                        // Handle in client/server implementations
+                    }
+                }
+            }
+            Ok(Some(payload))
+        } else {
+            Err(Error::IllegalActionBeforeOpen())
+        }
+    }
+
+    pub(crate) fn heartbeat(&self) -> Result<()> {
+        *self.last_heartbeat.write()? = Instant::now();
+        Ok(())
+    }
+
+    /// Calls the error callback with a given message.
+    #[inline]
+    fn call_error_callback(&self, text: String) -> Result<()> {
+        if let Some(function) = self.on_error.as_ref() {
+            spawn_scoped!(function(text));
+        }
+        Ok(())
+    }
+
+    fn handle_packet(&self, packet: Packet) -> Result<()> {
+        if let Some(on_packet) = self.on_packet.as_ref() {
+            spawn_scoped!(on_packet(packet));
+        }
+        Ok(())
+    }
+
+    fn handle_data(&self, data: Bytes) -> Result<()> {
+        if let Some(on_data) = self.on_data.as_ref() {
+            spawn_scoped!(on_data(data));
+        }
+        Ok(())
+    }
+
+    fn handle_close(&self) -> Result<()> {
+        if let Some(on_close) = self.on_close.as_ref() {
+            spawn_scoped!(on_close(()));
+        }
+        Ok(())
+    }
+}
+impl crate::model::Socket for InnerSocket {
+    fn close(&self) -> Result<()> {
         self.emit(Packet::new(PacketId::Close, Bytes::new()))?;
         self.connected.store(false, Ordering::Release);
         Ok(())
@@ -59,7 +138,7 @@ impl Socket {
 
     /// Opens the connection to a specified server. The first Pong packet is sent
     /// to the server to trigger the Ping-cycle.
-    pub fn connect(&self) -> Result<()> {
+    fn connect(&self) -> Result<()> {
         // SAFETY: Has valid handshake due to type
         self.connected.store(true, Ordering::Release);
 
@@ -68,7 +147,7 @@ impl Socket {
         }
 
         // set the last ping to now and set the connected state
-        *self.last_ping.lock()? = Instant::now();
+        self.heartbeat()?;
 
         // emit a pong packet to keep trigger the ping cycle on the server
         self.emit(Packet::new(PacketId::Pong, Bytes::new()))?;
@@ -77,7 +156,7 @@ impl Socket {
     }
 
     /// Sends a packet to the server.
-    pub fn emit(&self, packet: Packet) -> Result<()> {
+    fn emit(&self, packet: Packet) -> Result<()> {
         if !self.connected.load(Ordering::Acquire) {
             let error = Error::IllegalActionBeforeOpen();
             self.call_error_callback(format!("{}", error))?;
@@ -102,66 +181,16 @@ impl Socket {
         Ok(())
     }
 
-    /// Polls for next payload
-    pub(crate) fn poll(&self) -> Result<Option<Payload>> {
-        if self.connected.load(Ordering::Acquire) {
-            let data = self.transport.as_transport().poll()?;
-
-            if data.is_empty() {
-                return Ok(None);
-            }
-
-            Ok(Some(Payload::try_from(data)?))
-        } else {
-            Err(Error::IllegalActionBeforeOpen())
-        }
-    }
-
-    /// Calls the error callback with a given message.
-    #[inline]
-    fn call_error_callback(&self, text: String) -> Result<()> {
-        if let Some(function) = self.on_error.as_ref() {
-            spawn_scoped!(function(text));
-        }
-        Ok(())
-    }
-
     // Check if the underlying transport client is connected.
-    pub(crate) fn is_connected(&self) -> Result<bool> {
+    fn is_connected(&self) -> Result<bool> {
         Ok(self.connected.load(Ordering::Acquire))
-    }
-
-    pub(crate) fn pinged(&self) -> Result<()> {
-        *self.last_ping.lock()? = Instant::now();
-        Ok(())
-    }
-
-    pub(crate) fn handle_packet(&self, packet: Packet) -> Result<()> {
-        if let Some(on_packet) = self.on_packet.as_ref() {
-            spawn_scoped!(on_packet(packet));
-        }
-        Ok(())
-    }
-
-    pub(crate) fn handle_data(&self, data: Bytes) -> Result<()> {
-        if let Some(on_data) = self.on_data.as_ref() {
-            spawn_scoped!(on_data(data));
-        }
-        Ok(())
-    }
-
-    pub(crate) fn handle_close(&self) -> Result<()> {
-        if let Some(on_close) = self.on_close.as_ref() {
-            spawn_scoped!(on_close(()));
-        }
-        Ok(())
     }
 }
 
-impl Debug for Socket {
+impl Debug for InnerSocket {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!(
-            "EngineSocket(transport: {:?}, on_error: {:?}, on_open: {:?}, on_close: {:?}, on_packet: {:?}, on_data: {:?}, connected: {:?}, last_ping: {:?}, last_pong: {:?}, connection_data: {:?})",
+            "EngineSocketCommon(transport: {:?}, on_error: {:?}, on_open: {:?}, on_close: {:?}, on_packet: {:?}, on_data: {:?}, connected: {:?}, last_heartbeat: {:?}, connection_data: {:?})",
             self.transport,
             self.on_error,
             self.on_open,
@@ -169,8 +198,7 @@ impl Debug for Socket {
             self.on_packet,
             self.on_data,
             self.connected,
-            self.last_ping,
-            self.last_pong,
+            self.last_heartbeat,
             self.connection_data,
         ))
     }

--- a/socketio/src/error.rs
+++ b/socketio/src/error.rs
@@ -33,9 +33,6 @@ pub enum Error {
     IllegalActionBeforeOpen(),
     #[error("string is not json serializable: {0}")]
     InvalidJson(#[from] JsonError),
-    #[error("An illegal action (such as setting a callback after being connected) was triggered")]
-    //TODO: make these impossible by using builders and immutable data.
-    IllegalActionAfterOpen(),
     #[error("A lock was poisoned")]
     InvalidPoisonedLock(),
     #[error("Got an IO-Error: {0}")]

--- a/socketio/src/socket.rs
+++ b/socketio/src/socket.rs
@@ -36,9 +36,7 @@ pub struct Ack {
 
 /// Handles communication in the `socket.io` protocol.
 #[derive(Clone)]
-pub struct Socket<
-    EngineSocket: rust_engineio::model::Socket + Send + Sync + Clone + 'static + Debug,
-> {
+pub struct Socket<EngineSocket: rust_engineio::model::Socket + 'static> {
     engine_socket: Arc<EngineSocket>,
     host: Arc<Url>,
     connected: Arc<AtomicBool>,
@@ -50,7 +48,7 @@ pub struct Socket<
 }
 
 // TODO: change this to after .clone is refactored
-// impl<EngineSocket: rust_engineio::model::Socket + Send + Sync + Clone + 'static> Socket<EngineSocket> {
+// impl<EngineSocket: rust_engineio::model::Socket + 'static> Socket<EngineSocket> {
 impl Socket<rust_engineio::client::Socket> {
     /// Creates an instance of `Socket`.
     pub(super) fn new<T: Into<String>>(
@@ -519,7 +517,7 @@ impl Debug for Ack {
     }
 }
 
-impl<T: rust_engineio::model::Socket + Send + Sync + Clone + Debug> Debug for Socket<T> {
+impl<T: rust_engineio::model::Socket + Debug> Debug for Socket<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("Socket(engine_socket: {:?}, host: {:?}, connected: {:?}, on: <defined callbacks>, outstanding_acks: {:?}, nsp: {:?})",
             self.engine_socket,
@@ -531,10 +529,7 @@ impl<T: rust_engineio::model::Socket + Send + Sync + Clone + Debug> Debug for So
     }
 }
 
-pub(crate) struct Iter<
-    'a,
-    EngineSocket: rust_engineio::model::Socket + Send + Sync + Clone + 'static + Debug,
-> {
+pub(crate) struct Iter<'a, EngineSocket: rust_engineio::model::Socket + 'static> {
     socket: &'a Socket<EngineSocket>,
     engine_iter: rust_engineio::client::Iter<'a>,
 }


### PR DESCRIPTION
Base of https://github.com/1c3t3a/rust-socketio/pull/103
Breaking changes:
- cannot register callbacks on socket, only in builder
- removal of the IllegalActionBeforeOpen type