### PR TITLE
! 0.3.0 socketio callback refactor

### DIFF
--- a/engineio/src/client/socket.rs
+++ b/engineio/src/client/socket.rs
@@ -301,7 +301,7 @@ impl Socket {
     }
 
     /// Polls for next payload
-    //TODO: private?
+    #[doc(hidden)]
     pub fn poll(&self) -> Result<Option<Packet>> {
         let packet = self.socket.poll()?;
         if let Some(packet) = packet {

--- a/engineio/src/packet.rs
+++ b/engineio/src/packet.rs
@@ -159,12 +159,6 @@ impl Payload {
     pub fn len(&self) -> usize {
         self.0.len()
     }
-
-    pub fn iter(&self) -> Iter {
-        Iter {
-            iter: self.0.iter(),
-        }
-    }
 }
 
 impl TryFrom<Bytes> for Payload {
@@ -207,18 +201,7 @@ impl TryFrom<Payload> for Bytes {
     }
 }
 
-pub struct Iter<'a> {
-    iter: std::slice::Iter<'a, Packet>,
-}
-
-impl<'a> Iterator for Iter<'a> {
-    type Item = &'a Packet;
-    fn next(&mut self) -> std::option::Option<<Self as std::iter::Iterator>::Item> {
-        self.iter.next()
-    }
-}
-
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IntoIter {
     iter: std::vec::IntoIter<Packet>,
 }

--- a/engineio/src/socket.rs
+++ b/engineio/src/socket.rs
@@ -122,11 +122,10 @@ impl Socket {
                     let iter = iter.as_mut().unwrap();
                     if let Some(packet) = iter.next() {
                         return Ok(Some(packet));
-                    } else {
-                        // Iterator has run out of packets, get a new payload
                     }
                 }
 
+                // Iterator has run out of packets, get a new payload
                 // TODO: timeout?
                 let data = self.transport.as_transport().poll()?;
 

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -1,0 +1,256 @@
+use super::super::{event::Event, payload::Payload};
+use super::callback::Callback;
+use crate::Socket;
+use native_tls::TlsConnector;
+use rust_engineio::client::SocketBuilder as EngineIoSocketBuilder;
+use rust_engineio::header::{HeaderMap, HeaderValue};
+use url::Url;
+
+use crate::error::{Error, Result};
+use std::collections::HashMap;
+use std::thread;
+
+use crate::socket::Socket as InnerSocket;
+
+/// Flavor of engineio transport
+#[derive(Clone, Eq, PartialEq)]
+pub enum TransportType {
+    Any,
+    Websocket,
+    WebsocketUpgrade,
+    Polling,
+}
+
+/// A builder class for a `socket.io` socket. This handles setting up the client and
+/// configuring the callback, the namespace and metadata of the socket. If no
+/// namespace is specified, the default namespace `/` is taken. The `connect` method
+/// acts the `build` method and returns a connected [`Socket`].
+pub struct SocketBuilder {
+    address: String,
+    on: HashMap<Event, Callback>,
+    namespace: String,
+    tls_config: Option<TlsConnector>,
+    opening_headers: Option<HeaderMap>,
+    transport_type: TransportType,
+}
+
+impl SocketBuilder {
+    /// Create as client builder from a URL. URLs must be in the form
+    /// `[ws or wss or http or https]://[domain]:[port]/[path]`. The
+    /// path of the URL is optional and if no port is given, port 80
+    /// will be used.
+    /// # Example
+    /// ```rust
+    /// use rust_socketio::{SocketBuilder, Payload};
+    /// use serde_json::json;
+    ///
+    ///
+    /// let callback = |payload: Payload, _| {
+    ///            match payload {
+    ///                Payload::String(str) => println!("Received: {}", str),
+    ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///            }
+    /// };
+    ///
+    /// let mut socket = SocketBuilder::new("http://localhost:4200")
+    ///     .namespace("/admin")
+    ///     .on("test", callback)
+    ///     .connect()
+    ///     .expect("error while connecting");
+    ///
+    /// // use the socket
+    /// let json_payload = json!({"token": 123});
+    ///
+    /// let result = socket.emit("foo", json_payload);
+    ///
+    /// assert!(result.is_ok());
+    /// ```
+    pub fn new<T: Into<String>>(address: T) -> Self {
+        Self {
+            address: address.into(),
+            on: HashMap::new(),
+            namespace: "/".to_owned(),
+            tls_config: None,
+            opening_headers: None,
+            transport_type: TransportType::Any,
+        }
+    }
+
+    /// Sets the target namespace of the client. The namespace should start
+    /// with a leading `/`. Valid examples are e.g. `/admin`, `/foo`.
+    pub fn namespace<T: Into<String>>(mut self, namespace: T) -> Self {
+        let mut nsp = namespace.into();
+        if !nsp.starts_with('/') {
+            nsp = "/".to_owned() + &nsp;
+        }
+        self.namespace = nsp;
+        self
+    }
+
+    /// Registers a new callback for a certain [`socketio::event::Event`]. The event could either be
+    /// one of the common events like `message`, `error`, `connect`, `close` or a custom
+    /// event defined by a string, e.g. `onPayment` or `foo`.
+    /// # Example
+    /// ```rust
+    /// use rust_socketio::{SocketBuilder, Payload};
+    ///
+    /// let callback = |payload: Payload, _| {
+    ///            match payload {
+    ///                Payload::String(str) => println!("Received: {}", str),
+    ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///            }
+    /// };
+    ///
+    /// let socket = SocketBuilder::new("http://localhost:4200/")
+    ///     .namespace("/admin")
+    ///     .on("test", callback)
+    ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))
+    ///     .connect();
+    ///
+    /// ```
+    pub fn on<F>(mut self, event: &str, callback: F) -> Self
+    where
+        F: for<'a> FnMut(Payload, &'a Socket) + 'static + Sync + Send,
+    {
+        self.on.insert(event.into(), Callback::new(callback));
+        self
+    }
+
+    /// Uses a preconfigured TLS connector for secure cummunication. This configures
+    /// both the `polling` as well as the `websocket` transport type.
+    /// # Example
+    /// ```rust
+    /// use rust_socketio::{SocketBuilder, Payload};
+    /// use native_tls::TlsConnector;
+    ///
+    /// let tls_connector =  TlsConnector::builder()
+    ///            .use_sni(true)
+    ///            .build()
+    ///            .expect("Found illegal configuration");
+    ///
+    /// let socket = SocketBuilder::new("http://localhost:4200/")
+    ///     .namespace("/admin")
+    ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))
+    ///     .tls_config(tls_connector)
+    ///     .connect();
+    ///
+    /// ```
+    pub fn tls_config(mut self, tls_config: TlsConnector) -> Self {
+        self.tls_config = Some(tls_config);
+        self
+    }
+
+    /// Sets custom http headers for the opening request. The headers will be passed to the underlying
+    /// transport type (either websockets or polling) and then get passed with every request thats made.
+    /// via the transport layer.
+    /// # Example
+    /// ```rust
+    /// use rust_socketio::{SocketBuilder, Payload};
+    ///
+    ///
+    /// let socket = SocketBuilder::new("http://localhost:4200/")
+    ///     .namespace("/admin")
+    ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))
+    ///     .opening_header("accept-encoding", "application/json")
+    ///     .connect();
+    ///
+    /// ```
+    pub fn opening_header<T: Into<HeaderValue>, K: Into<String>>(mut self, key: K, val: T) -> Self {
+        match self.opening_headers {
+            Some(ref mut map) => {
+                map.insert(key.into(), val.into());
+            }
+            None => {
+                let mut map = HeaderMap::new();
+                map.insert(key.into(), val.into());
+                self.opening_headers = Some(map);
+            }
+        }
+        self
+    }
+
+    /// Specifies which underlying transport type to use
+    // TODO: better docs
+    pub fn transport_type(mut self, transport_type: TransportType) -> Self {
+        self.transport_type = transport_type;
+
+        self
+    }
+
+    /// Connects the socket to a certain endpoint. This returns a connected
+    /// [`Socket`] instance. This method returns an [`std::result::Result::Err`]
+    /// value if something goes wrong during connection.
+    /// # Example
+    /// ```rust
+    /// use rust_socketio::{SocketBuilder, Payload};
+    /// use serde_json::json;
+    ///
+    ///
+    /// let mut socket = SocketBuilder::new("http://localhost:4200/")
+    ///     .namespace("/admin")
+    ///     .on("error", |err, _| eprintln!("Socket error!: {:#?}", err))
+    ///     .connect()
+    ///     .expect("connection failed");
+    ///
+    /// // use the socket
+    /// let json_payload = json!({"token": 123});
+    ///
+    /// let result = socket.emit("foo", json_payload);
+    ///
+    /// assert!(result.is_ok());
+    /// ```
+    pub fn connect(self) -> Result<Socket> {
+        let socket = self.connect_manual()?;
+        // TODO: fix me
+        let socket_clone = socket.clone();
+
+        // Use thread to consume items in iterator in order to call callbacks
+        thread::spawn(move || {
+            // tries to restart a poll cycle whenever a 'normal' error occurs,
+            // it just panics on network errors, in case the poll cycle returned
+            // `Result::Ok`, the server receives a close frame so it's safe to
+            // terminate
+            for packet in socket_clone.iter() {
+                if let e @ Err(Error::IncompleteResponseFromEngineIo(_)) = packet {
+                    //TODO: handle errors
+                    panic!("{}", e.unwrap_err())
+                }
+            }
+        });
+
+        Ok(socket)
+    }
+
+    //TODO: stabilize
+    pub(crate) fn connect_manual(self) -> Result<Socket> {
+        // Parse url here rather than in new to keep new returning Self.
+        let mut url = Url::parse(&self.address)?;
+
+        if url.path() == "/" {
+            url.set_path("/socket.io/");
+        }
+
+        let mut builder = EngineIoSocketBuilder::new(url);
+
+        if let Some(tls_config) = self.tls_config {
+            builder = builder.tls_config(tls_config);
+        }
+        if let Some(headers) = self.opening_headers {
+            builder = builder.headers(headers);
+        }
+
+        let engine_socket = match self.transport_type {
+            TransportType::Any => builder.build_with_fallback()?,
+            TransportType::Polling => builder.build_polling()?,
+            TransportType::Websocket => builder.build_websocket()?,
+            TransportType::WebsocketUpgrade => builder.build_websocket_with_upgrade()?,
+        };
+
+        let inner_socket = InnerSocket::new(engine_socket)?;
+
+        let socket = Socket::new(inner_socket, &self.namespace, self.on)?;
+        socket.connect()?;
+
+        Ok(socket)
+    }
+}

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -90,6 +90,9 @@ impl SocketBuilder {
     /// Registers a new callback for a certain [`socketio::event::Event`]. The event could either be
     /// one of the common events like `message`, `error`, `connect`, `close` or a custom
     /// event defined by a string, e.g. `onPayment` or `foo`.
+    ///
+    /// Stored closures MUST annotate &Socket due to a quirk with Rust's lifetime inference.
+    ///
     /// # Example
     /// ```rust
     /// use rust_socketio::{SocketBuilder, Payload};

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -45,7 +45,7 @@ impl SocketBuilder {
     /// use serde_json::json;
     ///
     ///
-    /// let callback = |payload: Payload, socket: &Socket| {
+    /// let callback = |payload: Payload, socket: Socket| {
     ///            match payload {
     ///                Payload::String(str) => println!("Received: {}", str),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
@@ -111,7 +111,7 @@ impl SocketBuilder {
     /// ```
     pub fn on<F>(mut self, event: &str, callback: F) -> Self
     where
-        F: for<'a> FnMut(Payload, &'a Socket) + 'static + Sync + Send,
+        F: for<'a> FnMut(Payload, Socket) + 'static + Sync + Send,
     {
         self.on.insert(event.into(), Callback::new(callback));
         self

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -41,11 +41,11 @@ impl SocketBuilder {
     /// will be used.
     /// # Example
     /// ```rust
-    /// use rust_socketio::{SocketBuilder, Payload};
+    /// use rust_socketio::{SocketBuilder, Payload, Socket};
     /// use serde_json::json;
     ///
     ///
-    /// let callback = |payload: Payload, _| {
+    /// let callback = |payload: Payload, socket: &Socket| {
     ///            match payload {
     ///                Payload::String(str) => println!("Received: {}", str),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
@@ -94,16 +94,14 @@ impl SocketBuilder {
     /// ```rust
     /// use rust_socketio::{SocketBuilder, Payload};
     ///
-    /// let callback = |payload: Payload, _| {
+    /// let socket = SocketBuilder::new("http://localhost:4200/")
+    ///     .namespace("/admin")
+    ///     .on("test", |payload: Payload, _| {
     ///            match payload {
     ///                Payload::String(str) => println!("Received: {}", str),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
     ///            }
-    /// };
-    ///
-    /// let socket = SocketBuilder::new("http://localhost:4200/")
-    ///     .namespace("/admin")
-    ///     .on("test", callback)
+    ///     })
     ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))
     ///     .connect();
     ///

--- a/socketio/src/client/callback.rs
+++ b/socketio/src/client/callback.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{Payload, Socket};
 
-type InnerCallback = Box<dyn for<'a> FnMut(Payload, &'a Socket) + 'static + Sync + Send>;
+type InnerCallback = Box<dyn for<'a> FnMut(Payload, Socket) + 'static + Sync + Send>;
 
 pub(crate) struct Callback {
     inner: InnerCallback,
@@ -18,7 +18,7 @@ impl Debug for Callback {
 }
 
 impl Deref for Callback {
-    type Target = dyn for<'a> FnMut(Payload, &'a Socket) + 'static + Sync + Send;
+    type Target = dyn for<'a> FnMut(Payload, Socket) + 'static + Sync + Send;
 
     fn deref(&self) -> &Self::Target {
         self.inner.as_ref()
@@ -34,7 +34,7 @@ impl DerefMut for Callback {
 impl Callback {
     pub(crate) fn new<T>(callback: T) -> Self
     where
-        T: for<'a> FnMut(Payload, &'a Socket) + 'static + Sync + Send,
+        T: for<'a> FnMut(Payload, Socket) + 'static + Sync + Send,
     {
         Callback {
             inner: Box::new(callback),

--- a/socketio/src/client/callback.rs
+++ b/socketio/src/client/callback.rs
@@ -1,0 +1,43 @@
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+
+use crate::{Payload, Socket};
+
+type InnerCallback = Box<dyn for<'a> FnMut(Payload, &'a Socket) + 'static + Sync + Send>;
+
+pub(crate) struct Callback {
+    inner: InnerCallback,
+}
+
+impl Debug for Callback {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Callback")
+    }
+}
+
+impl Deref for Callback {
+    type Target = dyn for<'a> FnMut(Payload, &'a Socket) + 'static + Sync + Send;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.as_ref()
+    }
+}
+
+impl DerefMut for Callback {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.as_mut()
+    }
+}
+
+impl Callback {
+    pub(crate) fn new<T>(callback: T) -> Self
+    where
+        T: for<'a> FnMut(Payload, &'a Socket) + 'static + Sync + Send,
+    {
+        Callback {
+            inner: Box::new(callback),
+        }
+    }
+}

--- a/socketio/src/client/mod.rs
+++ b/socketio/src/client/mod.rs
@@ -1,2 +1,7 @@
+mod builder;
 mod socket;
-pub use socket::{Socket, SocketBuilder};
+pub use builder::SocketBuilder;
+pub use builder::TransportType;
+pub use socket::Socket;
+/// Internal callback type
+mod callback;

--- a/socketio/src/client/socket.rs
+++ b/socketio/src/client/socket.rs
@@ -1,250 +1,40 @@
 pub use super::super::{event::Event, payload::Payload};
-use crate::packet::Packet as SocketPacket;
-use native_tls::TlsConnector;
-use rust_engineio::client::{Socket as EngineIoSocket, SocketBuilder as EngineIoSocketBuilder};
-use rust_engineio::header::{HeaderMap, HeaderValue};
-use url::Url;
+use super::callback::Callback;
+use crate::packet::{Packet, PacketId};
+use rand::{thread_rng, Rng};
 
 use crate::error::Result;
-use std::{time::Duration, vec};
+use std::collections::HashMap;
+use std::ops::DerefMut;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use std::time::Instant;
 
 use crate::socket::Socket as InnerSocket;
+
+/// Represents an `Ack` as given back to the caller. Holds the internal `id` as
+/// well as the current ack'ed state. Holds data which will be accessible as
+/// soon as the ack'ed state is set to true. An `Ack` that didn't get ack'ed
+/// won't contain data.
+#[derive(Debug)]
+pub struct Ack {
+    pub id: i32,
+    timeout: Duration,
+    time_started: Instant,
+    callback: Callback,
+}
 
 /// A socket which handles communication with the server. It's initialized with
 /// a specific address as well as an optional namespace to connect to. If `None`
 /// is given the server will connect to the default namespace `"/"`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Socket {
     /// The inner socket client to delegate the methods to.
-    // TODO: Make this private
-    pub socket: InnerSocket,
-}
-
-type SocketCallback = dyn FnMut(Payload, Socket) + 'static + Sync + Send;
-
-/// Flavor of engineio transport
-//TODO: Consider longevity
-#[derive(Clone, Eq, PartialEq)]
-pub enum TransportType {
-    Any,
-    Websocket,
-    WebsocketUpgrade,
-    Polling,
-}
-
-/// A builder class for a `socket.io` socket. This handles setting up the client and
-/// configuring the callback, the namespace and metadata of the socket. If no
-/// namespace is specified, the default namespace `/` is taken. The `connect` method
-/// acts the `build` method and returns a connected [`Socket`].
-pub struct SocketBuilder {
-    address: String,
-    on: Option<Vec<(Event, Box<SocketCallback>)>>,
-    namespace: Option<String>,
-    tls_config: Option<TlsConnector>,
-    opening_headers: Option<HeaderMap>,
-    transport_type: TransportType,
-}
-
-impl SocketBuilder {
-    /// Create as client builder from a URL. URLs must be in the form
-    /// `[ws or wss or http or https]://[domain]:[port]/[path]`. The
-    /// path of the URL is optional and if no port is given, port 80
-    /// will be used.
-    /// # Example
-    /// ```rust
-    /// use rust_socketio::{SocketBuilder, Payload};
-    /// use serde_json::json;
-    ///
-    ///
-    /// let callback = |payload: Payload, _| {
-    ///            match payload {
-    ///                Payload::String(str) => println!("Received: {}", str),
-    ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
-    ///            }
-    /// };
-    ///
-    /// let mut socket = SocketBuilder::new("http://localhost:4200")
-    ///     .namespace("/admin")
-    ///     .on("test", callback)
-    ///     .connect()
-    ///     .expect("error while connecting");
-    ///
-    /// // use the socket
-    /// let json_payload = json!({"token": 123});
-    ///
-    /// let result = socket.emit("foo", json_payload);
-    ///
-    /// assert!(result.is_ok());
-    /// ```
-    pub fn new<T: Into<String>>(address: T) -> Self {
-        Self {
-            address: address.into(),
-            on: None,
-            namespace: None,
-            tls_config: None,
-            opening_headers: None,
-            transport_type: TransportType::Any,
-        }
-    }
-
-    /// Sets the target namespace of the client. The namespace should start
-    /// with a leading `/`. Valid examples are e.g. `/admin`, `/foo`.
-    pub fn namespace<T: Into<String>>(mut self, namespace: T) -> Self {
-        let mut nsp = namespace.into();
-        if !nsp.starts_with('/') {
-            nsp = "/".to_owned() + &nsp;
-        }
-        self.namespace = Some(nsp);
-        self
-    }
-
-    /// Registers a new callback for a certain [`socketio::event::Event`]. The event could either be
-    /// one of the common events like `message`, `error`, `connect`, `close` or a custom
-    /// event defined by a string, e.g. `onPayment` or `foo`.
-    /// # Example
-    /// ```rust
-    /// use rust_socketio::{SocketBuilder, Payload};
-    ///
-    /// let callback = |payload: Payload, _| {
-    ///            match payload {
-    ///                Payload::String(str) => println!("Received: {}", str),
-    ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
-    ///            }
-    /// };
-    ///
-    /// let socket = SocketBuilder::new("http://localhost:4200/")
-    ///     .namespace("/admin")
-    ///     .on("test", callback)
-    ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))
-    ///     .connect();
-    ///
-    /// ```
-    pub fn on<F>(mut self, event: &str, callback: F) -> Self
-    where
-        F: FnMut(Payload, Socket) + 'static + Sync + Send,
-    {
-        match self.on {
-            Some(ref mut vector) => vector.push((event.into(), Box::new(callback))),
-            None => self.on = Some(vec![(event.into(), Box::new(callback))]),
-        }
-        self
-    }
-
-    /// Uses a preconfigured TLS connector for secure cummunication. This configures
-    /// both the `polling` as well as the `websocket` transport type.
-    /// # Example
-    /// ```rust
-    /// use rust_socketio::{SocketBuilder, Payload};
-    /// use native_tls::TlsConnector;
-    ///
-    /// let tls_connector =  TlsConnector::builder()
-    ///            .use_sni(true)
-    ///            .build()
-    ///            .expect("Found illegal configuration");
-    ///
-    /// let socket = SocketBuilder::new("http://localhost:4200/")
-    ///     .namespace("/admin")
-    ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))
-    ///     .tls_config(tls_connector)
-    ///     .connect();
-    ///
-    /// ```
-    pub fn tls_config(mut self, tls_config: TlsConnector) -> Self {
-        self.tls_config = Some(tls_config);
-        self
-    }
-
-    /// Sets custom http headers for the opening request. The headers will be passed to the underlying
-    /// transport type (either websockets or polling) and then get passed with every request thats made.
-    /// via the transport layer.
-    /// # Example
-    /// ```rust
-    /// use rust_socketio::{SocketBuilder, Payload};
-    ///
-    ///
-    /// let socket = SocketBuilder::new("http://localhost:4200/")
-    ///     .namespace("/admin")
-    ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))
-    ///     .opening_header("accept-encoding", "application/json")
-    ///     .connect();
-    ///
-    /// ```
-    pub fn opening_header<T: Into<HeaderValue>, K: Into<String>>(mut self, key: K, val: T) -> Self {
-        match self.opening_headers {
-            Some(ref mut map) => {
-                map.insert(key.into(), val.into());
-            }
-            None => {
-                let mut map = HeaderMap::new();
-                map.insert(key.into(), val.into());
-                self.opening_headers = Some(map);
-            }
-        }
-        self
-    }
-
-    /// Specifies which underlying transport type to use
-    // TODO: better docs
-    pub fn transport_type(mut self, transport_type: TransportType) -> Self {
-        self.transport_type = transport_type;
-
-        self
-    }
-
-    /// Connects the socket to a certain endpoint. This returns a connected
-    /// [`Socket`] instance. This method returns an [`std::result::Result::Err`]
-    /// value if something goes wrong during connection.
-    /// # Example
-    /// ```rust
-    /// use rust_socketio::{SocketBuilder, Payload};
-    /// use serde_json::json;
-    ///
-    ///
-    /// let mut socket = SocketBuilder::new("http://localhost:4200/")
-    ///     .namespace("/admin")
-    ///     .on("error", |err, _| eprintln!("Socket error!: {:#?}", err))
-    ///     .connect()
-    ///     .expect("connection failed");
-    ///
-    /// // use the socket
-    /// let json_payload = json!({"token": 123});
-    ///
-    /// let result = socket.emit("foo", json_payload);
-    ///
-    /// assert!(result.is_ok());
-    /// ```
-    pub fn connect(self) -> Result<Socket> {
-        let mut url = Url::parse(&self.address)?;
-
-        if url.path() == "/" {
-            url.set_path("/socket.io/");
-        }
-
-        let mut builder = EngineIoSocketBuilder::new(url);
-
-        if let Some(tls_config) = self.tls_config {
-            builder = builder.tls_config(tls_config);
-        }
-        if let Some(headers) = self.opening_headers {
-            builder = builder.headers(headers);
-        }
-
-        let socket = match self.transport_type {
-            TransportType::Any => builder.build_with_fallback()?,
-            TransportType::Polling => builder.build_polling()?,
-            TransportType::Websocket => builder.build_websocket()?,
-            TransportType::WebsocketUpgrade => builder.build_websocket_with_upgrade()?,
-        };
-
-        let mut socket = Socket::new_with_socket(self.address, self.namespace, socket)?;
-        if let Some(callbacks) = self.on {
-            for (event, callback) in callbacks {
-                socket.on(event, Box::new(callback)).unwrap();
-            }
-        }
-        socket.connect()?;
-        Ok(socket)
-    }
+    socket: InnerSocket,
+    on: Arc<RwLock<HashMap<Event, Callback>>>,
+    outstanding_acks: Arc<RwLock<Vec<Ack>>>,
+    // namespace, for multiplexing messages
+    nsp: String,
 }
 
 impl Socket {
@@ -253,41 +43,31 @@ impl Socket {
     /// `"/"` is taken.
     /// ```
     pub(crate) fn new<T: Into<String>>(
-        address: T,
-        namespace: Option<String>,
-        tls_config: Option<TlsConnector>,
-        opening_headers: Option<HeaderMap>,
+        socket: InnerSocket,
+        namespace: T,
+        on: HashMap<Event, Callback>,
     ) -> Result<Self> {
         Ok(Socket {
-            socket: InnerSocket::new(address, namespace, tls_config, opening_headers)?,
+            socket,
+            nsp: namespace.into(),
+            on: Arc::new(RwLock::new(on)),
+            outstanding_acks: Arc::new(RwLock::new(Vec::new())),
         })
-    }
-
-    pub(crate) fn new_with_socket<T: Into<String>>(
-        address: T,
-        namespace: Option<String>,
-        engine_socket: EngineIoSocket,
-    ) -> Result<Self> {
-        Ok(Socket {
-            socket: InnerSocket::new_with_socket(address, namespace, engine_socket)?,
-        })
-    }
-
-    /// Registers a new callback for a certain event. This returns an
-    /// `Error::IllegalActionAfterOpen` error if the callback is registered
-    /// after a call to the `connect` method.
-    pub(crate) fn on<F>(&mut self, event: Event, callback: Box<F>) -> Result<()>
-    where
-        F: FnMut(Payload, Self) + 'static + Sync + Send,
-    {
-        self.socket.on(event, callback)
     }
 
     /// Connects the client to a server. Afterwards the `emit_*` methods can be
     /// called to interact with the server. Attention: it's not allowed to add a
     /// callback after a call to this method.
-    pub(crate) fn connect(&mut self) -> Result<()> {
-        self.socket.connect()
+    pub(crate) fn connect(&self) -> Result<()> {
+        // Connect the underlying socket
+        self.socket.connect()?;
+
+        // construct the opening packet
+        let open_packet = Packet::new(PacketId::Connect, self.nsp.clone(), None, None, 0, None);
+
+        self.socket.send(open_packet)?;
+
+        Ok(())
     }
 
     /// Sends a message to the server using the underlying `engine.io` protocol.
@@ -321,7 +101,7 @@ impl Socket {
         E: Into<Event>,
         D: Into<Payload>,
     {
-        self.socket.emit(event.into(), data.into())
+        self.socket.emit(&self.nsp, event.into(), data.into())
     }
 
     /// Disconnects this client from the server by sending a `socket.io` closing
@@ -347,8 +127,14 @@ impl Socket {
     /// socket.disconnect();
     ///
     /// ```
-    pub fn disconnect(&mut self) -> Result<()> {
-        self.socket.disconnect()
+    pub fn disconnect(&self) -> Result<()> {
+        let disconnect_packet =
+            Packet::new(PacketId::Disconnect, self.nsp.clone(), None, None, 0, None);
+
+        self.socket.send(disconnect_packet)?;
+        self.socket.disconnect()?;
+
+        Ok(())
     }
 
     /// Sends a message to the server but `alloc`s an `ack` to check whether the
@@ -397,29 +183,203 @@ impl Socket {
         callback: F,
     ) -> Result<()>
     where
-        F: FnMut(Payload, Socket) + 'static + Send + Sync,
+        F: for<'a> FnMut(Payload, &'a Socket) + 'static + Sync + Send,
         E: Into<Event>,
         D: Into<Payload>,
     {
-        self.socket
-            .emit_with_ack(event.into(), data.into(), timeout, callback)
+        let id = thread_rng().gen_range(0..999);
+        let socket_packet =
+            self.socket
+                .build_packet_for_payload(data.into(), event.into(), &self.nsp, Some(id))?;
+
+        let ack = Ack {
+            id,
+            time_started: Instant::now(),
+            timeout,
+            callback: Callback::new(callback),
+        };
+
+        // add the ack to the tuple of outstanding acks
+        self.outstanding_acks.write()?.push(ack);
+
+        self.socket.send(socket_packet)?;
+        Ok(())
+    }
+
+    pub(crate) fn poll(&self) -> Result<Option<Packet>> {
+        loop {
+            match self.socket.poll() {
+                Err(err) => {
+                    self.callback(&Event::Error, err.to_string())?;
+                    return Err(err.into());
+                }
+                Ok(Some(packet)) => {
+                    if packet.nsp == self.nsp {
+                        self.handle_socketio_packet(&packet)?;
+                        return Ok(Some(packet));
+                    } else {
+                        // Not our namespace continue polling
+                    }
+                }
+                Ok(None) => return Ok(None),
+            }
+        }
     }
 
     pub(crate) fn iter(&self) -> Iter {
-        Iter {
-            socket_iter: self.socket.iter(),
+        Iter { socket: self }
+    }
+
+    fn callback<P: Into<Payload>>(&self, event: &Event, payload: P) -> Result<()> {
+        let mut on = self.on.write()?;
+        let lock = on.deref_mut();
+        if let Some(callback) = lock.get_mut(event) {
+            callback(payload.into(), self);
         }
+        drop(lock);
+        drop(on);
+        Ok(())
+    }
+
+    /// Handles the incoming acks and classifies what callbacks to call and how.
+    #[inline]
+    fn handle_ack(&self, socket_packet: &Packet) -> Result<()> {
+        let mut to_be_removed = Vec::new();
+        if let Some(id) = socket_packet.id {
+            for (index, ack) in self.outstanding_acks.write()?.iter_mut().enumerate() {
+                if ack.id == id {
+                    to_be_removed.push(index);
+
+                    if ack.time_started.elapsed() < ack.timeout {
+                        if let Some(ref payload) = socket_packet.data {
+                            ack.callback.deref_mut()(Payload::String(payload.to_owned()), self);
+                        }
+                        if let Some(ref attachments) = socket_packet.attachments {
+                            if let Some(payload) = attachments.get(0) {
+                                ack.callback.deref_mut()(Payload::Binary(payload.to_owned()), self);
+                            }
+                        }
+                    } else {
+                        // Do something with timed out acks?
+                    }
+                }
+            }
+            for index in to_be_removed {
+                self.outstanding_acks.write()?.remove(index);
+            }
+        }
+        Ok(())
+    }
+
+    /// Handles a binary event.
+    #[inline]
+    fn handle_binary_event(&self, packet: &Packet) -> Result<()> {
+        let event = if let Some(string_data) = &packet.data {
+            string_data.replace("\"", "").into()
+        } else {
+            Event::Message
+        };
+
+        if let Some(attachments) = &packet.attachments {
+            if let Some(binary_payload) = attachments.get(0) {
+                self.callback(&event, Payload::Binary(binary_payload.to_owned()))?;
+            }
+        }
+        Ok(())
+    }
+
+    /// A method for handling the Event Socket Packets.
+    // this could only be called with an event
+    fn handle_event(&self, packet: &Packet) -> Result<()> {
+        // unwrap the potential data
+        if let Some(data) = &packet.data {
+            // the string must be a valid json array with the event at index 0 and the
+            // payload at index 1. if no event is specified, the message callback is used
+            if let Ok(serde_json::Value::Array(contents)) =
+                serde_json::from_str::<serde_json::Value>(&data)
+            {
+                let event: Event = if contents.len() > 1 {
+                    contents
+                        .get(0)
+                        .map(|value| match value {
+                            serde_json::Value::String(ev) => ev,
+                            _ => "message",
+                        })
+                        .unwrap_or("message")
+                        .into()
+                } else {
+                    Event::Message
+                };
+                self.callback(
+                    &event,
+                    contents
+                        .get(1)
+                        .unwrap_or_else(|| contents.get(0).unwrap())
+                        .to_string(),
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Handles the incoming messages and classifies what callbacks to call and how.
+    /// This method is later registered as the callback for the `on_data` event of the
+    /// engineio client.
+    #[inline]
+    fn handle_socketio_packet(&self, packet: &Packet) -> Result<()> {
+        if packet.nsp == self.nsp {
+            match packet.packet_type {
+                PacketId::Ack | PacketId::BinaryAck => match self.handle_ack(&packet) {
+                    Err(err) => {
+                        self.callback(&Event::Error, err.to_string())?;
+                        return Err(err.into());
+                    }
+                    Ok(_) => (),
+                },
+                PacketId::BinaryEvent => {
+                    if let Err(err) = self.handle_binary_event(&packet) {
+                        self.callback(&Event::Error, err.to_string())?;
+                    }
+                }
+                PacketId::Connect => {
+                    self.callback(&Event::Connect, "")?;
+                }
+                PacketId::Disconnect => {
+                    self.callback(&Event::Close, "")?;
+                }
+                PacketId::ConnectError => {
+                    self.callback(
+                        &Event::Error,
+                        String::from("Received an ConnectError frame: ")
+                            + &packet
+                                .clone()
+                                .data
+                                .unwrap_or_else(|| String::from("\"No error message provided\"")),
+                    )?;
+                }
+                PacketId::Event => {
+                    if let Err(err) = self.handle_event(&packet) {
+                        self.callback(&Event::Error, err.to_string())?;
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 
 pub(crate) struct Iter<'a> {
-    socket_iter: crate::socket::Iter<'a>,
+    socket: &'a Socket,
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = Result<SocketPacket>;
+    type Item = Result<Packet>;
     fn next(&mut self) -> std::option::Option<<Self as std::iter::Iterator>::Item> {
-        self.socket_iter.next()
+        match self.socket.poll() {
+            Err(err) => return Some(Err(err)),
+            Ok(Some(packet)) => return Some(Ok(packet)),
+            Ok(None) => return None,
+        }
     }
 }
 
@@ -429,7 +389,7 @@ mod test {
     use std::thread::sleep;
 
     use super::*;
-    use crate::payload::Payload;
+    use crate::{client::TransportType, payload::Payload, SocketBuilder};
     use bytes::Bytes;
     use native_tls::TlsConnector;
     use serde_json::json;
@@ -438,28 +398,21 @@ mod test {
     #[test]
     fn socket_io_integration() -> Result<()> {
         //TODO: check to make sure we are receiving packets rather than logging.
-        let url = crate::test::socket_io_server()?;
+        let url = crate::test::socket_io_server();
 
-        let mut socket = Socket::new(url, None, None, None)?;
-
-        let result = socket.on(
-            "test".into(),
-            Box::new(|msg, _| match msg {
+        let socket = SocketBuilder::new(url)
+            .on("test", |msg, _| match msg {
                 Payload::String(str) => println!("Received string: {}", str),
                 Payload::Binary(bin) => println!("Received binary data: {:#?}", bin),
-            }),
-        );
-        assert!(result.is_ok());
-
-        let result = socket.connect();
-        assert!(result.is_ok());
+            })
+            .connect()?;
 
         let payload = json!({"token": 123});
         let result = socket.emit("test", Payload::String(payload.to_string()));
 
         assert!(result.is_ok());
 
-        let ack_callback = move |message: Payload, socket: Socket| {
+        let ack_callback = move |message: Payload, socket: &Socket| {
             let result = socket.emit(
                 "test",
                 Payload::String(json!({"got ack": true}).to_string()),
@@ -481,7 +434,7 @@ mod test {
         );
         assert!(ack.is_ok());
 
-        sleep(Duration::from_secs(10));
+        sleep(Duration::from_secs(3));
 
         assert!(socket.disconnect().is_ok());
 
@@ -490,7 +443,7 @@ mod test {
 
     #[test]
     fn socket_io_builder_integration() -> Result<()> {
-        let url = crate::test::socket_io_server()?;
+        let url = crate::test::socket_io_server();
 
         // test socket build logic
         let socket_builder = SocketBuilder::new(url.clone());
@@ -513,13 +466,16 @@ mod test {
 
         assert!(socket.emit("binary", Bytes::from_static(&[46, 88])).is_ok());
 
-        let ack_cb = |payload, _| {
-            println!("Yehaa the ack got acked");
-            println!("With data: {:#?}", payload);
-        };
-
         assert!(socket
-            .emit_with_ack("binary", json!("pls ack"), Duration::from_secs(1), ack_cb,)
+            .emit_with_ack(
+                "binary",
+                json!("pls ack"),
+                Duration::from_secs(1),
+                |payload, _| {
+                    println!("Yehaa the ack got acked");
+                    println!("With data: {:#?}", payload);
+                }
+            )
             .is_ok());
 
         sleep(Duration::from_secs(5));
@@ -539,4 +495,145 @@ mod test {
 
         Ok(())
     }
+
+    fn test_socketio_socket(socket: Socket) -> Result<()> {
+        let mut iter = socket
+            .iter()
+            .map(|packet| packet.unwrap())
+            .filter(|packet| packet.packet_type != PacketId::Connect);
+
+        let packet: Option<Packet> = iter.next();
+        assert!(packet.is_some());
+
+        let packet = packet.unwrap();
+
+        assert_eq!(
+            packet,
+            Packet::new(
+                PacketId::Event,
+                "/".to_owned(),
+                Some("[\"Hello from the message event!\"]".to_owned()),
+                None,
+                0,
+                None,
+            )
+        );
+
+        let packet: Option<Packet> = iter.next();
+        assert!(packet.is_some());
+
+        let packet = packet.unwrap();
+
+        assert_eq!(
+            packet,
+            Packet::new(
+                PacketId::Event,
+                "/".to_owned(),
+                Some("[\"test\",\"Hello from the test event!\"]".to_owned()),
+                None,
+                0,
+                None
+            )
+        );
+
+        let packet: Option<Packet> = iter.next();
+        assert!(packet.is_some());
+
+        let packet = packet.unwrap();
+        assert_eq!(
+            packet,
+            Packet::new(
+                PacketId::BinaryEvent,
+                "/".to_owned(),
+                None,
+                None,
+                1,
+                Some(vec![Bytes::from_static(&[4, 5, 6])]),
+            )
+        );
+
+        let packet: Option<Packet> = iter.next();
+        assert!(packet.is_some());
+
+        let packet = packet.unwrap();
+        assert_eq!(
+            packet,
+            Packet::new(
+                PacketId::BinaryEvent,
+                "/".to_owned(),
+                Some("\"test\"".to_owned()),
+                None,
+                1,
+                Some(vec![Bytes::from_static(&[1, 2, 3])]),
+            )
+        );
+
+        assert!(socket
+            .emit_with_ack(
+                "test",
+                Payload::String("123".to_owned()),
+                Duration::from_secs(10),
+                |message: Payload, _| {
+                    println!("Yehaa! My ack got acked?");
+                    if let Payload::String(str) = message {
+                        println!("Received string ack");
+                        println!("Ack data: {}", str);
+                    }
+                }
+            )
+            .is_ok());
+
+        Ok(())
+    }
+
+    fn builder() -> SocketBuilder {
+        let url = crate::test::socket_io_server();
+        SocketBuilder::new(url)
+            .on("test".into(), |message, _| {
+                if let Payload::String(st) = message {
+                    println!("{}", st)
+                }
+            })
+            .on("Error".into(), |_, _| {})
+            .on("Connect".into(), |_, _| {})
+            .on("Close".into(), |_, _| {})
+    }
+
+    #[test]
+    fn test_connection() -> Result<()> {
+        let socket = builder()
+            .transport_type(TransportType::Any)
+            .connect_manual()?;
+
+        test_socketio_socket(socket)
+    }
+
+    #[test]
+    fn test_connection_polling() -> Result<()> {
+        let socket = builder()
+            .transport_type(TransportType::Polling)
+            .connect_manual()?;
+
+        test_socketio_socket(socket)
+    }
+
+    #[test]
+    fn test_connection_websocket() -> Result<()> {
+        let socket = builder()
+            .transport_type(TransportType::Websocket)
+            .connect_manual()?;
+
+        test_socketio_socket(socket)
+    }
+
+    #[test]
+    fn test_connection_websocket_upgrade() -> Result<()> {
+        let socket = builder()
+            .transport_type(TransportType::WebsocketUpgrade)
+            .connect_manual()?;
+
+        test_socketio_socket(socket)
+    }
+
+    // TODO: add secure socketio server
 }

--- a/socketio/src/client/socket.rs
+++ b/socketio/src/client/socket.rs
@@ -150,6 +150,8 @@ impl Socket {
     /// called. The callback consumes a [`Payload`] which represents the data send
     /// by the server.
     ///
+    /// Stored closures MUST annotate &Socket due to a quirk with Rust's lifetime inference.
+    ///
     /// # Example
     /// ```
     /// use rust_socketio::{SocketBuilder, Payload, Socket};

--- a/socketio/src/client/socket.rs
+++ b/socketio/src/client/socket.rs
@@ -82,7 +82,7 @@ impl Socket {
     /// use serde_json::json;
     ///
     /// let mut socket = SocketBuilder::new("http://localhost:4200/")
-    ///     .on("test", |payload: Payload, socket: Socket| {
+    ///     .on("test", |payload: Payload, socket: &Socket| {
     ///         println!("Received: {:#?}", payload);
     ///         socket.emit("test", json!({"hello": true})).expect("Server unreachable");
     ///      })
@@ -111,11 +111,13 @@ impl Socket {
     /// use rust_socketio::{SocketBuilder, Payload, Socket};
     /// use serde_json::json;
     ///
+    /// fn handle_test(payload: Payload, socket: &Socket) {
+    ///     println!("Received: {:#?}", payload);
+    ///     socket.emit("test", json!({"hello": true})).expect("Server unreachable");
+    /// }
+    ///
     /// let mut socket = SocketBuilder::new("http://localhost:4200/")
-    ///     .on("test", |payload: Payload, socket: Socket| {
-    ///         println!("Received: {:#?}", payload);
-    ///         socket.emit("test", json!({"hello": true})).expect("Server unreachable");
-    ///      })
+    ///     .on("test", handle_test)
     ///     .connect()
     ///     .expect("connection failed");
     ///
@@ -150,7 +152,7 @@ impl Socket {
     ///
     /// # Example
     /// ```
-    /// use rust_socketio::{SocketBuilder, Payload};
+    /// use rust_socketio::{SocketBuilder, Payload, Socket};
     /// use serde_json::json;
     /// use std::time::Duration;
     /// use std::thread::sleep;
@@ -161,8 +163,10 @@ impl Socket {
     ///     .expect("connection failed");
     ///
     ///
-    ///
-    /// let ack_callback = |message: Payload, _| {
+    /// // &Socket MUST be annotated when storing a closure in a variable before
+    /// // passing to emit_with_awk. Inline closures and calling functions work as
+    /// // intended.
+    /// let ack_callback = |message: Payload, socket: &Socket| {
     ///     match message {
     ///         Payload::String(str) => println!("{}", str),
     ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),

--- a/socketio/src/client/socket.rs
+++ b/socketio/src/client/socket.rs
@@ -232,7 +232,7 @@ impl Socket {
         }
     }
 
-    pub(crate) fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter {
         Iter { socket: self }
     }
 
@@ -380,7 +380,7 @@ impl Socket {
     }
 }
 
-pub(crate) struct Iter<'a> {
+pub struct Iter<'a> {
     socket: &'a Socket,
 }
 

--- a/socketio/src/event.rs
+++ b/socketio/src/event.rs
@@ -1,5 +1,5 @@
 /// An `Event` in `socket.io` could either (`Message`, `Error`) or custom.
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Eq, Hash)]
 pub enum Event {
     Message,
     Error,

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -9,7 +9,7 @@
 //! // define a callback which is called when a payload is received
 //! // this callback gets the payload as well as an instance of the
 //! // socket to communicate with the server
-//! let callback = |payload: Payload, socket: Socket| {
+//! let callback = |payload: Payload, socket: &Socket| {
 //!        match payload {
 //!            Payload::String(str) => println!("Received: {}", str),
 //!            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
@@ -31,7 +31,7 @@
 //! socket.emit("foo", json_payload).expect("Server unreachable");
 //!
 //! // define a callback, that's executed when the ack got acked
-//! let ack_callback = |message: Payload, _| {
+//! let ack_callback = |message: Payload, _: &Socket| {
 //!     println!("Yehaa! My ack got acked?");
 //!     println!("Ack data: {:#?}", message);
 //! };

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -9,7 +9,7 @@
 //! // define a callback which is called when a payload is received
 //! // this callback gets the payload as well as an instance of the
 //! // socket to communicate with the server
-//! let callback = |payload: Payload, socket: &Socket| {
+//! let callback = |payload: Payload, socket: Socket| {
 //!        match payload {
 //!            Payload::String(str) => println!("Received: {}", str),
 //!            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
@@ -31,7 +31,7 @@
 //! socket.emit("foo", json_payload).expect("Server unreachable");
 //!
 //! // define a callback, that's executed when the ack got acked
-//! let ack_callback = |message: Payload, _: &Socket| {
+//! let ack_callback = |message: Payload, _: Socket| {
 //!     println!("Yehaa! My ack got acked?");
 //!     println!("Ack data: {:#?}", message);
 //! };

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -79,16 +79,6 @@
 #![warn(clippy::style)]
 #![warn(clippy::perf)]
 #![warn(clippy::correctness)]
-/// A small macro that spawns a scoped thread. Used for calling the callback
-/// functions.
-macro_rules! spawn_scoped {
-    ($e:expr) => {
-        crossbeam_utils::thread::scope(|s| {
-            s.spawn(|_| $e);
-        })
-        .unwrap();
-    };
-}
 
 /// Defines client only structs
 pub mod client;
@@ -137,14 +127,14 @@ pub(crate) mod test {
             .unwrap())
     }
 
-    pub(crate) fn socket_io_server() -> crate::error::Result<Url> {
+    pub(crate) fn socket_io_server() -> Url {
         let url = std::env::var("SOCKET_IO_SERVER").unwrap_or_else(|_| SERVER_URL.to_owned());
-        let mut url = Url::parse(&url)?;
+        let mut url = Url::parse(&url).unwrap();
 
         if url.path() == "/" {
             url.set_path("/socket.io/");
         }
 
-        Ok(url)
+        url
     }
 }

--- a/socketio/src/socket.rs
+++ b/socketio/src/socket.rs
@@ -1,193 +1,57 @@
-use crate::client::Socket as SocketIoSocket;
 use crate::error::{Error, Result};
-use crate::packet::{Packet as SocketPacket, PacketId as SocketPacketId};
+use crate::packet::{Packet, PacketId};
 use bytes::Bytes;
-use native_tls::TlsConnector;
-use rand::{thread_rng, Rng};
-use rust_engineio::header::HeaderMap;
-use rust_engineio::{
-    Packet as EnginePacket, PacketId as EnginePacketId, Socket as EngineIoSocket,
-    SocketBuilder as EngineIoSocketBuilder,
-};
+use rust_engineio::{Packet as EnginePacket, PacketId as EnginePacketId, Socket as EngineSocket};
 use std::convert::TryFrom;
-use std::thread;
-use std::{
-    fmt::Debug,
-    sync::{atomic::Ordering, RwLock},
-};
-use std::{
-    sync::{atomic::AtomicBool, Arc},
-    time::{Duration, Instant},
-};
-use url::Url;
+use std::sync::{atomic::AtomicBool, Arc};
+use std::{fmt::Debug, sync::atomic::Ordering};
 
 use super::{event::Event, payload::Payload};
 
-/// The type of a callback function.
-// TODO: refactor SocketIoSocket out
-pub(crate) type Callback<I> = RwLock<Box<dyn FnMut(I, SocketIoSocket) + 'static + Sync + Send>>;
-
-pub(crate) type EventCallback = (Event, Callback<Payload>);
-/// Represents an `Ack` as given back to the caller. Holds the internal `id` as
-/// well as the current ack'ed state. Holds data which will be accessible as
-/// soon as the ack'ed state is set to true. An `Ack` that didn't get ack'ed
-/// won't contain data.
-pub struct Ack {
-    pub id: i32,
-    timeout: Duration,
-    time_started: Instant,
-    callback: Callback<Payload>,
-}
-
 /// Handles communication in the `socket.io` protocol.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Socket {
-    engine_socket: Arc<EngineIoSocket>,
-    host: Arc<Url>,
+    //TODO: 0.4.0 refactor this
+    engine_socket: Arc<EngineSocket>,
     connected: Arc<AtomicBool>,
-    // TODO: Move this to client/socket.rs
-    on: Arc<Vec<EventCallback>>,
-    outstanding_acks: Arc<RwLock<Vec<Ack>>>,
-    // namespace, for multiplexing messages
-    pub(crate) nsp: Arc<Option<String>>,
 }
 
 impl Socket {
     /// Creates an instance of `Socket`.
-    pub(super) fn new<T: Into<String>>(
-        address: T,
-        nsp: Option<String>,
-        tls_config: Option<TlsConnector>,
-        opening_headers: Option<HeaderMap>,
-    ) -> Result<Self> {
-        let mut url: Url = Url::parse(&address.into())?;
 
-        if url.path() == "/" {
-            url.set_path("/socket.io/");
-        }
-
-        let mut engine_socket_builder = EngineIoSocketBuilder::new(url.clone());
-        if let Some(tls_config) = tls_config {
-            // SAFETY: Checked is_some
-            engine_socket_builder = engine_socket_builder.tls_config(tls_config);
-        }
-        if let Some(opening_headers) = opening_headers {
-            // SAFETY: Checked is_some
-            engine_socket_builder = engine_socket_builder.headers(opening_headers);
-        }
-
-        let engine_socket = engine_socket_builder.build_with_fallback()?;
-
-        Self::new_with_socket(url.to_string(), nsp, engine_socket)
-    }
-
-    pub(super) fn new_with_socket<T: Into<String>>(
-        address: T,
-        nsp: Option<String>,
-        engine_socket: EngineIoSocket,
-    ) -> Result<Self> {
-        let mut url: Url = Url::parse(&address.into())?;
-
-        if url.path() == "/" {
-            url.set_path("/socket.io/");
-        }
-
+    pub(super) fn new(engine_socket: EngineSocket) -> Result<Self> {
         Ok(Socket {
             engine_socket: Arc::new(engine_socket),
-            host: Arc::new(url),
             connected: Arc::new(AtomicBool::default()),
-            on: Arc::new(Vec::new()),
-            outstanding_acks: Arc::new(RwLock::new(Vec::new())),
-            nsp: Arc::new(nsp),
         })
-    }
-
-    /// Registers a new event with some callback function `F`.
-    pub fn on<F>(&mut self, event: Event, callback: Box<F>) -> Result<()>
-    where
-        F: FnMut(Payload, SocketIoSocket) + 'static + Sync + Send,
-    {
-        Arc::get_mut(&mut self.on)
-            .unwrap()
-            .push((event, RwLock::new(callback)));
-        Ok(())
     }
 
     /// Connects to the server. This includes a connection of the underlying
     /// engine.io client and afterwards an opening socket.io request.
-    pub fn connect(&mut self) -> Result<()> {
-        self.connect_with_thread(true)
-    }
-
-    /// Connect with optional thread to forward events to callback
-    pub(super) fn connect_with_thread(&mut self, thread: bool) -> Result<()> {
+    pub fn connect(&self) -> Result<()> {
         self.engine_socket.connect()?;
-
-        // TODO: refactor me
-        // TODO: This is needed (somewhere) to get callbacks to work.
-        if thread {
-            let clone_self = self.clone();
-            thread::spawn(move || {
-                // tries to restart a poll cycle whenever a 'normal' error occurs,
-                // it just panics on network errors, in case the poll cycle returned
-                // `Result::Ok`, the server receives a close frame so it's safe to
-                // terminate
-                let iter = clone_self.iter();
-                for packet in iter {
-                    if let e @ Err(Error::IncompleteResponseFromEngineIo(_)) = packet {
-                        panic!("{}", e.unwrap_err())
-                    }
-                }
-            });
-        }
-
-        // construct the opening packet
-        let open_packet = SocketPacket::new(
-            SocketPacketId::Connect,
-            self.nsp
-                .as_ref()
-                .as_ref()
-                .unwrap_or(&String::from("/"))
-                .to_owned(),
-            None,
-            None,
-            0,
-            None,
-        );
 
         // store the connected value as true, if the connection process fails
         // later, the value will be updated
         self.connected.store(true, Ordering::Release);
-        self.send(open_packet)
+
+        Ok(())
     }
 
     /// Disconnects from the server by sending a socket.io `Disconnect` packet. This results
     /// in the underlying engine.io transport to get closed as well.
-    pub fn disconnect(&mut self) -> Result<()> {
-        if !self.is_engineio_connected()? || !self.connected.load(Ordering::Acquire) {
-            return Err(Error::IllegalActionAfterOpen());
+    pub fn disconnect(&self) -> Result<()> {
+        if self.is_engineio_connected()? {
+            self.engine_socket.disconnect()?;
         }
-
-        let disconnect_packet = SocketPacket::new(
-            SocketPacketId::Disconnect,
-            self.nsp
-                .as_ref()
-                .as_ref()
-                .unwrap_or(&String::from("/"))
-                .to_owned(),
-            None,
-            None,
-            0,
-            None,
-        );
-
-        self.send(disconnect_packet)?;
-        self.connected.store(false, Ordering::Release);
+        if self.connected.load(Ordering::Acquire) {
+            self.connected.store(false, Ordering::Release);
+        }
         Ok(())
     }
 
     /// Sends a `socket.io` packet to the server using the `engine.io` client.
-    pub fn send(&self, packet: SocketPacket) -> Result<()> {
+    pub fn send(&self, packet: Packet) -> Result<()> {
         if !self.is_engineio_connected()? || !self.connected.load(Ordering::Acquire) {
             return Err(Error::IllegalActionBeforeOpen());
         }
@@ -208,31 +72,28 @@ impl Socket {
 
     /// Emits to certain event with given data. The data needs to be JSON,
     /// otherwise this returns an `InvalidJson` error.
-    pub fn emit(&self, event: Event, data: Payload) -> Result<()> {
-        let default = String::from("/");
-        let nsp = self.nsp.as_ref().as_ref().unwrap_or(&default);
-
+    pub fn emit(&self, nsp: &str, event: Event, data: Payload) -> Result<()> {
         let socket_packet = self.build_packet_for_payload(data, event, nsp, None)?;
 
         self.send(socket_packet)
     }
 
     /// Returns a packet for a payload, could be used for bot binary and non binary
-    /// events and acks.
+    /// events and acks. Convenance method.
     #[inline]
-    fn build_packet_for_payload<'a>(
+    pub(crate) fn build_packet_for_payload<'a>(
         &'a self,
         payload: Payload,
         event: Event,
         nsp: &'a str,
         id: Option<i32>,
-    ) -> Result<SocketPacket> {
+    ) -> Result<Packet> {
         match payload {
-            Payload::Binary(bin_data) => Ok(SocketPacket::new(
+            Payload::Binary(bin_data) => Ok(Packet::new(
                 if id.is_some() {
-                    SocketPacketId::BinaryAck
+                    PacketId::BinaryAck
                 } else {
-                    SocketPacketId::BinaryEvent
+                    PacketId::BinaryEvent
                 },
                 nsp.to_owned(),
                 Some(serde_json::Value::String(event.into()).to_string()),
@@ -245,8 +106,8 @@ impl Socket {
 
                 let payload = format!("[\"{}\",{}]", String::from(event), str_data);
 
-                Ok(SocketPacket::new(
-                    SocketPacketId::Event,
+                Ok(Packet::new(
+                    PacketId::Event,
                     nsp.to_owned(),
                     Some(payload),
                     id,
@@ -257,110 +118,50 @@ impl Socket {
         }
     }
 
-    /// Emits and requests an `ack`. The `ack` returns a `Arc<RwLock<Ack>>` to
-    /// acquire shared mutability. This `ack` will be changed as soon as the
-    /// server answered with an `ack`.
-    pub fn emit_with_ack<F>(
-        &self,
-        event: Event,
-        data: Payload,
-        timeout: Duration,
-        callback: F,
-    ) -> Result<()>
-    where
-        F: FnMut(Payload, SocketIoSocket) + 'static + Send + Sync,
-    {
-        let id = thread_rng().gen_range(0..999);
-        let default = String::from("/");
-        let nsp = self.nsp.as_ref().as_ref().unwrap_or(&default);
-        let socket_packet = self.build_packet_for_payload(data, event, nsp, Some(id))?;
-
-        let ack = Ack {
-            id,
-            time_started: Instant::now(),
-            timeout,
-            callback: RwLock::new(Box::new(callback)),
-        };
-
-        // add the ack to the tuple of outstanding acks
-        self.outstanding_acks.write()?.push(ack);
-
-        self.send(socket_packet)?;
-        Ok(())
-    }
-
-    pub(crate) fn iter(&self) -> Iter {
-        Iter {
-            socket: self,
-            engine_iter: self.engine_socket.iter(),
+    pub(crate) fn poll(&self) -> Result<Option<Packet>> {
+        loop {
+            match self.engine_socket.poll() {
+                Ok(Some(packet)) => {
+                    if packet.packet_id == EnginePacketId::Message
+                        || packet.packet_id == EnginePacketId::MessageBinary
+                    {
+                        let packet = self.handle_engineio_packet(packet)?;
+                        self.handle_socketio_packet(&packet);
+                        return Ok(Some(packet));
+                    } else {
+                        continue;
+                    }
+                }
+                Ok(None) => {
+                    return Ok(None);
+                }
+                Err(err) => return Err(err.into()),
+            }
         }
     }
 
-    /// Handles the incoming messages and classifies what callbacks to call and how.
-    /// This method is later registered as the callback for the `on_data` event of the
-    /// engineio client.
+    /// Handles the connection/disconnection.
     #[inline]
-    fn handle_new_socketio_packet(&self, socket_packet: SocketPacket) -> Option<SocketPacket> {
-        let output = socket_packet.clone();
-
-        let default = String::from("/");
-        //TODO: should nsp logic be here?
-        if socket_packet.nsp != *self.nsp.as_ref().as_ref().unwrap_or(&default) {
-            return None;
-        }
-
+    fn handle_socketio_packet(&self, socket_packet: &Packet) {
         match socket_packet.packet_type {
-            SocketPacketId::Connect => {
+            PacketId::Connect => {
                 self.connected.store(true, Ordering::Release);
             }
-            SocketPacketId::ConnectError => {
-                self.connected.store(false, Ordering::Release);
-                if let Some(function) = self.get_event_callback(&Event::Error) {
-                    spawn_scoped!({
-                        let mut lock = function.1.write().unwrap();
-                        // TODO: refactor
-                        lock(
-                            Payload::String(
-                                String::from("Received an ConnectError frame")
-                                    + &socket_packet.data.unwrap_or_else(|| {
-                                        String::from("\"No error message provided\"")
-                                    }),
-                            ),
-                            SocketIoSocket {
-                                socket: self.clone(),
-                            },
-                        );
-                        drop(lock);
-                    });
-                }
-            }
-            SocketPacketId::Disconnect => {
+            PacketId::ConnectError => {
                 self.connected.store(false, Ordering::Release);
             }
-            SocketPacketId::Event => {
-                self.handle_event(socket_packet);
+            PacketId::Disconnect => {
+                self.connected.store(false, Ordering::Release);
             }
-            SocketPacketId::Ack | SocketPacketId::BinaryAck => {
-                self.handle_ack(socket_packet);
-            }
-            SocketPacketId::BinaryEvent => {
-                // in case of a binary event, check if this is the attachement or not and
-                // then either handle the event or set the open packet
-                self.handle_binary_event(socket_packet);
-            }
+            _ => (),
         }
-        Some(output)
     }
 
     /// Handles new incoming engineio packets
-    pub fn handle_new_engineio_packet(
-        &self,
-        engine_iter: &mut rust_engineio::client::Iter,
-        packet: EnginePacket,
-    ) -> Option<Result<SocketPacket>> {
-        let socket_packet = SocketPacket::try_from(&packet.data);
+    fn handle_engineio_packet(&self, packet: EnginePacket) -> Result<Packet> {
+        let socket_packet = Packet::try_from(&packet.data);
         if let Err(err) = socket_packet {
-            return Some(Err(err));
+            return Err(err);
         }
         // SAFETY: checked above to see if it was Err
         let mut socket_packet = socket_packet.unwrap();
@@ -369,436 +170,33 @@ impl Socket {
             let mut attachments_left = socket_packet.attachment_count;
             let mut attachments = Vec::new();
             while attachments_left > 0 {
-                let next = engine_iter.next()?;
+                let next = self.engine_socket.poll();
                 match next {
-                    Err(err) => return Some(Err(err.into())),
-                    Ok(packet) => match packet.packet_id {
+                    Err(err) => return Err(err.into()),
+                    Ok(Some(packet)) => match packet.packet_id {
                         EnginePacketId::MessageBinary | EnginePacketId::Message => {
                             attachments.push(packet.data);
                             attachments_left = attachments_left - 1;
                         }
                         _ => {
-                            return Some(Err(Error::InvalidAttachmentPacketType(
+                            return Err(Error::InvalidAttachmentPacketType(
                                 packet.packet_id.into(),
-                            )));
+                            ));
                         }
                     },
+                    Ok(None) => {
+                        // Engineio closed before attachments completed.
+                        return Err(Error::IncompletePacket());
+                    }
                 }
             }
             socket_packet.attachments = Some(attachments);
         }
 
-        let packet = self.handle_new_socketio_packet(socket_packet);
-        if let Some(packet) = packet {
-            return Some(Ok(packet));
-        } else {
-            return None;
-        }
-    }
-
-    /// Handles the incoming acks and classifies what callbacks to call and how.
-    #[inline]
-    fn handle_ack(&self, socket_packet: SocketPacket) {
-        let mut to_be_removed = Vec::new();
-        if let Some(id) = socket_packet.id {
-            for (index, ack) in self
-                .clone()
-                .outstanding_acks
-                .read()
-                .unwrap()
-                .iter()
-                .enumerate()
-            {
-                if ack.id == id {
-                    to_be_removed.push(index);
-
-                    if ack.time_started.elapsed() < ack.timeout {
-                        if let Some(ref payload) = socket_packet.data {
-                            spawn_scoped!({
-                                let mut function = ack.callback.write().unwrap();
-                                // TODO: refactor
-                                function(
-                                    Payload::String(payload.to_owned()),
-                                    SocketIoSocket {
-                                        socket: self.clone(),
-                                    },
-                                );
-                                drop(function);
-                            });
-                        }
-                        if let Some(ref attachments) = socket_packet.attachments {
-                            if let Some(payload) = attachments.get(0) {
-                                spawn_scoped!({
-                                    let mut function = ack.callback.write().unwrap();
-                                    // TODO: refactor
-                                    function(
-                                        Payload::Binary(payload.to_owned()),
-                                        SocketIoSocket {
-                                            socket: self.clone(),
-                                        },
-                                    );
-                                    drop(function);
-                                });
-                            }
-                        }
-                    }
-                }
-            }
-            for index in to_be_removed {
-                self.outstanding_acks.write().unwrap().remove(index);
-            }
-        }
-    }
-
-    /// Handles a binary event.
-    #[inline]
-    fn handle_binary_event(&self, socket_packet: SocketPacket) {
-        let event = if let Some(string_data) = socket_packet.data {
-            string_data.replace("\"", "").into()
-        } else {
-            Event::Message
-        };
-
-        if let Some(attachments) = socket_packet.attachments {
-            if let Some(binary_payload) = attachments.get(0) {
-                if let Some(function) = self.get_event_callback(&event) {
-                    spawn_scoped!({
-                        let mut lock = function.1.write().unwrap();
-                        // TODO: refactor
-                        lock(
-                            Payload::Binary(binary_payload.to_owned()),
-                            SocketIoSocket {
-                                socket: self.clone(),
-                            },
-                        );
-                        drop(lock);
-                    });
-                }
-            }
-        }
-    }
-
-    /// A method for handling the Event Socket Packets.
-    // this could only be called with an event
-    fn handle_event(&self, socket_packet: SocketPacket) {
-        // unwrap the potential data
-        if let Some(data) = socket_packet.data {
-            // the string must be a valid json array with the event at index 0 and the
-            // payload at index 1. if no event is specified, the message callback is used
-            if let Ok(serde_json::Value::Array(contents)) =
-                serde_json::from_str::<serde_json::Value>(&data)
-            {
-                let event: Event = if contents.len() > 1 {
-                    contents
-                        .get(0)
-                        .map(|value| match value {
-                            serde_json::Value::String(ev) => ev,
-                            _ => "message",
-                        })
-                        .unwrap_or("message")
-                        .into()
-                } else {
-                    Event::Message
-                };
-                // check which callback to use and call it with the data if it's present
-                if let Some(function) = self.get_event_callback(&event) {
-                    spawn_scoped!({
-                        let mut lock = function.1.write().unwrap();
-                        // if the data doesn't contain an event type at position `1`, the event must be
-                        // of the type `Message`, in that case the data must be on position one and
-                        // unwrapping is safe
-
-                        // TODO: refactor
-                        lock(
-                            Payload::String(
-                                contents
-                                    .get(1)
-                                    .unwrap_or_else(|| contents.get(0).unwrap())
-                                    .to_string(),
-                            ),
-                            SocketIoSocket {
-                                socket: self.clone(),
-                            },
-                        );
-                        drop(lock);
-                    });
-                }
-            }
-        }
-    }
-
-    /// A convenient method for finding a callback for a certain event.
-    #[inline]
-    fn get_event_callback(&self, event: &Event) -> Option<&(Event, Callback<Payload>)> {
-        self.on.iter().find(|item| item.0 == *event)
+        Ok(socket_packet)
     }
 
     fn is_engineio_connected(&self) -> Result<bool> {
         Ok(self.engine_socket.is_connected()?)
-    }
-}
-
-impl Debug for Ack {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!(
-            "Ack(id: {:?}), timeout: {:?}, time_started: {:?}, callback: {}",
-            self.id, self.timeout, self.time_started, "Fn(String)",
-        ))
-    }
-}
-
-impl Debug for Socket {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("Socket(engine_socket: {:?}, host: {:?}, connected: {:?}, on: <defined callbacks>, outstanding_acks: {:?}, nsp: {:?})",
-            self.engine_socket,
-            self.host,
-            self.connected,
-            self.outstanding_acks,
-            self.nsp,
-        ))
-    }
-}
-
-pub(crate) struct Iter<'a> {
-    socket: &'a Socket,
-    engine_iter: rust_engineio::client::Iter<'a>,
-}
-
-impl<'a> Iterator for Iter<'a> {
-    type Item = Result<SocketPacket>;
-    fn next(&mut self) -> std::option::Option<<Self as std::iter::Iterator>::Item> {
-        loop {
-            let next: std::result::Result<EnginePacket, rust_engineio::Error> =
-                self.engine_iter.next()?;
-
-            if let Err(err) = next {
-                return Some(Err(err.into()));
-            }
-            let next = next.unwrap();
-
-            match next.packet_id {
-                EnginePacketId::MessageBinary | EnginePacketId::Message => {
-                    match self
-                        .socket
-                        .handle_new_engineio_packet(&mut self.engine_iter, next)
-                    {
-                        None => {}
-                        Some(packet) => return Some(packet),
-                    }
-                }
-                EnginePacketId::Open => {
-                    if let Some(function) = self.socket.get_event_callback(&Event::Connect) {
-                        let mut lock = function.1.write().unwrap();
-                        // TODO: refactor
-                        lock(
-                            Payload::String(String::from("Connection is opened")),
-                            SocketIoSocket {
-                                socket: self.socket.clone(),
-                            },
-                        );
-                        drop(lock)
-                    }
-                }
-                EnginePacketId::Close => {
-                    if let Some(function) = self.socket.get_event_callback(&Event::Close) {
-                        let mut lock = function.1.write().unwrap();
-                        // TODO: refactor
-                        lock(
-                            Payload::String(String::from("Connection is closed")),
-                            SocketIoSocket {
-                                socket: self.socket.clone(),
-                            },
-                        );
-                        drop(lock)
-                    }
-                }
-                _ => (),
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use std::time::Duration;
-
-    use super::*;
-
-    fn test_socketio_socket(socket: Socket) -> Result<()> {
-        let mut socket = socket;
-
-        assert!(socket
-            .on(
-                "test".into(),
-                Box::new(|message, _| {
-                    if let Payload::String(st) = message {
-                        println!("{}", st)
-                    }
-                })
-            )
-            .is_ok());
-
-        assert!(socket.on("Error".into(), Box::new(|_, _| {})).is_ok());
-
-        assert!(socket.on("Connect".into(), Box::new(|_, _| {})).is_ok());
-
-        assert!(socket.on("Close".into(), Box::new(|_, _| {})).is_ok());
-
-        // Tests need to consume packets rather than forward to callbacks.
-        socket.connect_with_thread(false).unwrap();
-
-        let mut iter = socket
-            .iter()
-            .map(|packet| packet.unwrap())
-            .filter(|packet| packet.packet_type != SocketPacketId::Connect);
-
-        let packet: Option<SocketPacket> = iter.next();
-        assert!(packet.is_some());
-
-        let packet = packet.unwrap();
-
-        assert_eq!(
-            packet,
-            SocketPacket::new(
-                SocketPacketId::Event,
-                "/".to_owned(),
-                Some("[\"Hello from the message event!\"]".to_owned()),
-                None,
-                0,
-                None,
-            )
-        );
-
-        let packet: Option<SocketPacket> = iter.next();
-        assert!(packet.is_some());
-
-        let packet = packet.unwrap();
-
-        assert_eq!(
-            packet,
-            SocketPacket::new(
-                SocketPacketId::Event,
-                "/".to_owned(),
-                Some("[\"test\",\"Hello from the test event!\"]".to_owned()),
-                None,
-                0,
-                None
-            )
-        );
-
-        let packet: Option<SocketPacket> = iter.next();
-        assert!(packet.is_some());
-
-        let packet = packet.unwrap();
-        assert_eq!(
-            packet,
-            SocketPacket::new(
-                SocketPacketId::BinaryEvent,
-                "/".to_owned(),
-                None,
-                None,
-                1,
-                Some(vec![Bytes::from_static(&[4, 5, 6])]),
-            )
-        );
-
-        let packet: Option<SocketPacket> = iter.next();
-        assert!(packet.is_some());
-
-        let packet = packet.unwrap();
-        assert_eq!(
-            packet,
-            SocketPacket::new(
-                SocketPacketId::BinaryEvent,
-                "/".to_owned(),
-                Some("\"test\"".to_owned()),
-                None,
-                1,
-                Some(vec![Bytes::from_static(&[1, 2, 3])]),
-            )
-        );
-
-        let ack_callback = |message: Payload, _| {
-            println!("Yehaa! My ack got acked?");
-            if let Payload::String(str) = message {
-                println!("Received string ack");
-                println!("Ack data: {}", str);
-            }
-        };
-
-        assert!(socket
-            .emit_with_ack(
-                "test".into(),
-                Payload::String("123".to_owned()),
-                Duration::from_secs(10),
-                ack_callback
-            )
-            .is_ok());
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_connection() -> Result<()> {
-        let url = crate::test::socket_io_server()?;
-
-        let socket = Socket::new(url, None, None, None)?;
-
-        test_socketio_socket(socket)
-    }
-
-    #[test]
-    fn test_connection_failable() -> Result<()> {
-        let url = crate::test::socket_io_server()?;
-
-        let engine_socket = EngineIoSocketBuilder::new(url.clone()).build()?;
-
-        let socket = Socket::new_with_socket(url, None, engine_socket)?;
-
-        test_socketio_socket(socket)
-    }
-
-    //TODO: make all engineio code-paths reachable from engineio, (is_binary_attr is only used in socketio)
-    #[test]
-    fn test_connection_polling() -> Result<()> {
-        let url = crate::test::socket_io_server()?;
-
-        let engine_socket = EngineIoSocketBuilder::new(url.clone()).build_polling()?;
-
-        let socket = Socket::new_with_socket(url, None, engine_socket)?;
-
-        test_socketio_socket(socket)
-    }
-
-    #[test]
-    fn test_connection_websocket() -> Result<()> {
-        let url = crate::test::socket_io_server()?;
-
-        let engine_socket = EngineIoSocketBuilder::new(url.clone()).build_websocket()?;
-
-        let socket = Socket::new_with_socket(url, None, engine_socket)?;
-
-        test_socketio_socket(socket)
-    }
-
-    // TODO: add secure socketio server
-    /*
-    #[test]
-    fn test_connection_websocket_secure() -> Result<()> {
-        let url = crate::socketio::test::socket_io_server()?;
-
-        let engine_socket = EngineIoSocketBuilder::new(url.clone()).build()?;
-
-        let socket = Socket::new_with_socket(url, None, engine_socket)?;
-
-        test_socketio_socket(socket)
-    }
-    */
-
-    #[test]
-    fn test_error_cases() -> Result<()> {
-        let result = Socket::new("http://localhost:123", None, None, None);
-        assert!(result.is_err());
-        Ok(())
     }
 }


### PR DESCRIPTION
Sorry about the mega PR, things got out of hand. Did manage to make the code 200 lines shorter.

This PR cleans up 
- https://github.com/1c3t3a/rust-socketio/pull/101#discussion_r698482795
- https://github.com/1c3t3a/rust-socketio/pull/101#discussion_r698477692

Other notes:
- Iterator should be usable by users now (so long as they connect_manual)
- Implementing trait based callbacks should be relatively easy (see callback function)
- Will require some refactoring internally to get server implementation to share code (see hard coded engineio socket client in common socketio socket)

Breaking changes:
- Event type on callback no longer needs into