### PR TITLE
refactor!: rename socket to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ An implementation of a socket.io client written in the rust programming language
 ## Example usage
 
 ``` rust
-use rust_socketio::{SocketBuilder, Payload, Socket};
+use rust_socketio::{ClientBuilder, Payload, Client};
 use serde_json::json;
 use std::time::Duration;
 
 // define a callback which is called when a payload is received
 // this callback gets the payload as well as an instance of the
 // socket to communicate with the server
-let callback = |payload: Payload, socket: Socket| {
+let callback = |payload: Payload, socket: Client| {
        match payload {
            Payload::String(str) => println!("Received: {}", str),
            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
@@ -27,7 +27,7 @@ let callback = |payload: Payload, socket: Socket| {
 };
 
 // get a socket that is connected to the admin namespace
-let socket = SocketBuilder::new("http://localhost:4200")
+let socket = ClientBuilder::new("http://localhost:4200")
      .namespace("/admin")
      .on("test", callback)
      .on("error", |err, _| eprintln!("Error: {:#?}", err))
@@ -54,7 +54,7 @@ socket.disconnect().expect("Disconnect failed")
 
 ```
 
-The main entry point for using this crate is the `SocketBuilder` which provides a way to easily configure a socket in the needed way. When the `connect` method is called on the builder, it returns a connected client which then could be used to emit messages to certain events. One client can only be connected to one namespace. If you need to listen to the messages in different namespaces you need to allocate multiple sockets.
+The main entry point for using this crate is the `ClientBuilder` which provides a way to easily configure a socket in the needed way. When the `connect` method is called on the builder, it returns a connected client which then could be used to emit messages to certain events. One client can only be connected to one namespace. If you need to listen to the messages in different namespaces you need to allocate multiple sockets.
 
 ## Documentation
 

--- a/engineio/benches/engineio.rs
+++ b/engineio/benches/engineio.rs
@@ -5,7 +5,7 @@ use native_tls::TlsConnector;
 use rust_engineio::error::Error;
 use rust_engineio::{
     packet::{Packet, PacketId},
-    {Socket, SocketBuilder},
+    {Client, ClientBuilder},
 };
 use std::fs::File;
 use std::io::Read;
@@ -47,26 +47,26 @@ pub mod util {
 
 pub mod tests {
     use super::*;
-    pub fn engine_io_socket_build(url: Url) -> Result<Socket, Error> {
-        SocketBuilder::new(url).build()
+    pub fn engine_io_socket_build(url: Url) -> Result<Client, Error> {
+        ClientBuilder::new(url).build()
     }
 
-    pub fn engine_io_socket_build_polling(url: Url) -> Result<Socket, Error> {
-        SocketBuilder::new(url).build_polling()
+    pub fn engine_io_socket_build_polling(url: Url) -> Result<Client, Error> {
+        ClientBuilder::new(url).build_polling()
     }
 
-    pub fn engine_io_socket_build_polling_secure(url: Url) -> Result<Socket, Error> {
-        SocketBuilder::new(url)
+    pub fn engine_io_socket_build_polling_secure(url: Url) -> Result<Client, Error> {
+        ClientBuilder::new(url)
             .tls_config(tls_connector()?)
             .build_polling()
     }
 
-    pub fn engine_io_socket_build_websocket(url: Url) -> Result<Socket, Error> {
-        SocketBuilder::new(url).build_websocket()
+    pub fn engine_io_socket_build_websocket(url: Url) -> Result<Client, Error> {
+        ClientBuilder::new(url).build_websocket()
     }
 
-    pub fn engine_io_socket_build_websocket_secure(url: Url) -> Result<Socket, Error> {
-        SocketBuilder::new(url)
+    pub fn engine_io_socket_build_websocket_secure(url: Url) -> Result<Client, Error> {
+        ClientBuilder::new(url)
             .tls_config(tls_connector()?)
             .build_websocket()
     }
@@ -75,7 +75,7 @@ pub mod tests {
         Packet::new(PacketId::Message, Bytes::from("hello world"))
     }
 
-    pub fn engine_io_emit(socket: &Socket, packet: Packet) -> Result<(), Error> {
+    pub fn engine_io_emit(socket: &Client, packet: Packet) -> Result<(), Error> {
         socket.emit(packet)
     }
 }

--- a/engineio/src/client/mod.rs
+++ b/engineio/src/client/mod.rs
@@ -1,3 +1,3 @@
-mod socket;
-pub use socket::Iter;
-pub use {socket::Iter as SocketIter, socket::Socket, socket::SocketBuilder};
+mod client;
+pub use client::Iter;
+pub use {client::Client, client::ClientBuilder, client::Iter as SocketIter};

--- a/engineio/src/lib.rs
+++ b/engineio/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```
 //!
-//! The main entry point for using this crate is the [`SocketBuilder`] which provides
+//! The main entry point for using this crate is the [`ClientBuilder`] which provides
 //! a way to easily configure a socket in the needed way. When the `connect` method
 //! is called on the builder, it returns a connected client which then could be used
 //! to emit messages to certain events. One client can only be connected to one namespace.
@@ -64,7 +64,7 @@ pub const ENGINE_IO_VERSION: i32 = 4;
 /// crate. Handles all kinds of errors.
 pub mod error;
 
-pub use client::{Socket, SocketBuilder};
+pub use client::{Client, ClientBuilder};
 pub use error::Error;
 pub use packet::{Packet, PacketId};
 

--- a/socketio/examples/callback.rs
+++ b/socketio/examples/callback.rs
@@ -1,7 +1,7 @@
-use rust_socketio::{Event, Payload, Socket, SocketBuilder};
+use rust_socketio::{Client, ClientBuilder, Event, Payload};
 use serde_json::json;
 
-fn handle_foo(payload: Payload, socket: Socket) -> () {
+fn handle_foo(payload: Payload, socket: Client) -> () {
     socket.emit("bar", payload).expect("Server unreachable")
 }
 
@@ -9,7 +9,7 @@ fn main() {
     // define a callback which is called when a payload is received
     // this callback gets the payload as well as an instance of the
     // socket to communicate with the server
-    let handle_test = |payload: Payload, socket: Socket| {
+    let handle_test = |payload: Payload, socket: Client| {
         match payload {
             Payload::String(str) => println!("Received string: {}", str),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
@@ -20,13 +20,13 @@ fn main() {
     };
 
     // get a socket that is connected to the admin namespace
-    let socket = SocketBuilder::new("http://localhost:4200")
+    let socket = ClientBuilder::new("http://localhost:4200")
         .namespace("/admin")
         // Saved closure
         .on("test", handle_test)
         // Inline closure
         .on("error", |err, _| eprintln!("Error: {:#?}", err))
-        // Function call with signature (payload: Payload, socket: Socket) -> ()
+        // Function call with signature (payload: Payload, socket: Client) -> ()
         .on("foo", handle_foo)
         // Reserved event names are case insensitive
         .on("oPeN", |_, _| println!("Connected"))

--- a/socketio/examples/readme.rs
+++ b/socketio/examples/readme.rs
@@ -1,4 +1,4 @@
-use rust_socketio::{Payload, Socket, SocketBuilder};
+use rust_socketio::{Client, ClientBuilder, Payload};
 use serde_json::json;
 use std::time::Duration;
 
@@ -6,7 +6,7 @@ fn main() {
     // define a callback which is called when a payload is received
     // this callback gets the payload as well as an instance of the
     // socket to communicate with the server
-    let callback = |payload: Payload, socket: Socket| {
+    let callback = |payload: Payload, socket: Client| {
         match payload {
             Payload::String(str) => println!("Received: {}", str),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
@@ -17,7 +17,7 @@ fn main() {
     };
 
     // get a socket that is connected to the admin namespace
-    let socket = SocketBuilder::new("http://localhost:4200")
+    let socket = ClientBuilder::new("http://localhost:4200")
         .namespace("/admin")
         .on("test", callback)
         .on("error", |err, _| eprintln!("Error: {:#?}", err))

--- a/socketio/examples/secure.rs
+++ b/socketio/examples/secure.rs
@@ -1,6 +1,6 @@
 use native_tls::Certificate;
 use native_tls::TlsConnector;
-use rust_socketio::SocketBuilder;
+use rust_socketio::ClientBuilder;
 use std::fs::File;
 use std::io::Read;
 
@@ -19,7 +19,7 @@ fn main() {
         .build()
         .expect("Failed to build TLS Connector");
 
-    let socket = SocketBuilder::new("https://localhost:4200")
+    let socket = ClientBuilder::new("https://localhost:4200")
         .tls_config(tls_connector)
         // Not strictly required for HTTPS
         .opening_header("HOST", "localhost")

--- a/socketio/src/client/callback.rs
+++ b/socketio/src/client/callback.rs
@@ -3,10 +3,10 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use super::Socket;
+use super::Client;
 use crate::Payload;
 
-type InnerCallback = Box<dyn for<'a> FnMut(Payload, Socket) + 'static + Sync + Send>;
+type InnerCallback = Box<dyn for<'a> FnMut(Payload, Client) + 'static + Sync + Send>;
 
 pub(crate) struct Callback {
     inner: InnerCallback,
@@ -19,7 +19,7 @@ impl Debug for Callback {
 }
 
 impl Deref for Callback {
-    type Target = dyn for<'a> FnMut(Payload, Socket) + 'static + Sync + Send;
+    type Target = dyn for<'a> FnMut(Payload, Client) + 'static + Sync + Send;
 
     fn deref(&self) -> &Self::Target {
         self.inner.as_ref()
@@ -35,7 +35,7 @@ impl DerefMut for Callback {
 impl Callback {
     pub(crate) fn new<T>(callback: T) -> Self
     where
-        T: for<'a> FnMut(Payload, Socket) + 'static + Sync + Send,
+        T: for<'a> FnMut(Payload, Client) + 'static + Sync + Send,
     {
         Callback {
             inner: Box::new(callback),

--- a/socketio/src/client/mod.rs
+++ b/socketio/src/client/mod.rs
@@ -1,7 +1,7 @@
 mod builder;
-mod socket;
-pub use builder::SocketBuilder;
+mod client;
+pub use builder::ClientBuilder;
 pub use builder::TransportType;
-pub use socket::Socket;
+pub use client::Client;
 /// Internal callback type
 mod callback;

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -2,14 +2,14 @@
 //! ## Example usage
 //!
 //! ``` rust
-//! use rust_socketio::{SocketBuilder, Payload, Socket};
+//! use rust_socketio::{ClientBuilder, Payload, Client};
 //! use serde_json::json;
 //! use std::time::Duration;
 //!
 //! // define a callback which is called when a payload is received
 //! // this callback gets the payload as well as an instance of the
 //! // socket to communicate with the server
-//! let callback = |payload: Payload, socket: Socket| {
+//! let callback = |payload: Payload, socket: Client| {
 //!        match payload {
 //!            Payload::String(str) => println!("Received: {}", str),
 //!            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
@@ -18,7 +18,7 @@
 //! };
 //!
 //! // get a socket that is connected to the admin namespace
-//! let mut socket = SocketBuilder::new("http://localhost:4200/")
+//! let mut socket = ClientBuilder::new("http://localhost:4200/")
 //!      .namespace("/admin")
 //!      .on("test", callback)
 //!      .on("error", |err, _| eprintln!("Error: {:#?}", err))
@@ -31,7 +31,7 @@
 //! socket.emit("foo", json_payload).expect("Server unreachable");
 //!
 //! // define a callback, that's executed when the ack got acked
-//! let ack_callback = |message: Payload, _: Socket| {
+//! let ack_callback = |message: Payload, _: Client| {
 //!     println!("Yehaa! My ack got acked?");
 //!     println!("Ack data: {:#?}", message);
 //! };
@@ -44,7 +44,7 @@
 //!     .expect("Server unreachable");
 //! ```
 //!
-//! The main entry point for using this crate is the [`SocketBuilder`] which provides
+//! The main entry point for using this crate is the [`ClientBuilder`] which provides
 //! a way to easily configure a socket in the needed way. When the `connect` method
 //! is called on the builder, it returns a connected client which then could be used
 //! to emit messages to certain events. One client can only be connected to one namespace.
@@ -101,7 +101,11 @@ pub use error::Error;
 
 pub use {event::Event, payload::Payload};
 
-pub use client::{Socket, SocketBuilder, TransportType};
+pub use client::{Client, ClientBuilder, TransportType};
+
+// TODO: 0.4.0 remove
+#[deprecated(since = "0.3.0-alpha-2", note = "Socket renamed to Client")]
+pub use client::{Client as Socket, ClientBuilder as SocketBuilder};
 
 #[cfg(test)]
 pub(crate) mod test {

--- a/socketio/src/socket.rs
+++ b/socketio/src/socket.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, Result};
 use crate::packet::{Packet, PacketId};
 use bytes::Bytes;
-use rust_engineio::{Packet as EnginePacket, PacketId as EnginePacketId, Socket as EngineSocket};
+use rust_engineio::{Client as EngineClient, Packet as EnginePacket, PacketId as EnginePacketId};
 use std::convert::TryFrom;
 use std::sync::{atomic::AtomicBool, Arc};
 use std::{fmt::Debug, sync::atomic::Ordering};
@@ -10,18 +10,18 @@ use super::{event::Event, payload::Payload};
 
 /// Handles communication in the `socket.io` protocol.
 #[derive(Clone, Debug)]
-pub struct Socket {
+pub(crate) struct Socket {
     //TODO: 0.4.0 refactor this
-    engine_socket: Arc<EngineSocket>,
+    engine_client: Arc<EngineClient>,
     connected: Arc<AtomicBool>,
 }
 
 impl Socket {
     /// Creates an instance of `Socket`.
 
-    pub(super) fn new(engine_socket: EngineSocket) -> Result<Self> {
+    pub(super) fn new(engine_client: EngineClient) -> Result<Self> {
         Ok(Socket {
-            engine_socket: Arc::new(engine_socket),
+            engine_client: Arc::new(engine_client),
             connected: Arc::new(AtomicBool::default()),
         })
     }
@@ -29,7 +29,7 @@ impl Socket {
     /// Connects to the server. This includes a connection of the underlying
     /// engine.io client and afterwards an opening socket.io request.
     pub fn connect(&self) -> Result<()> {
-        self.engine_socket.connect()?;
+        self.engine_client.connect()?;
 
         // store the connected value as true, if the connection process fails
         // later, the value will be updated
@@ -42,7 +42,7 @@ impl Socket {
     /// in the underlying engine.io transport to get closed as well.
     pub fn disconnect(&self) -> Result<()> {
         if self.is_engineio_connected()? {
-            self.engine_socket.disconnect()?;
+            self.engine_client.disconnect()?;
         }
         if self.connected.load(Ordering::Acquire) {
             self.connected.store(false, Ordering::Release);
@@ -58,12 +58,12 @@ impl Socket {
 
         // the packet, encoded as an engine.io message packet
         let engine_packet = EnginePacket::new(EnginePacketId::Message, Bytes::from(&packet));
-        self.engine_socket.emit(engine_packet)?;
+        self.engine_client.emit(engine_packet)?;
 
         if let Some(attachments) = packet.attachments {
             for attachment in attachments {
                 let engine_packet = EnginePacket::new(EnginePacketId::MessageBinary, attachment);
-                self.engine_socket.emit(engine_packet)?;
+                self.engine_client.emit(engine_packet)?;
             }
         }
 
@@ -120,7 +120,7 @@ impl Socket {
 
     pub(crate) fn poll(&self) -> Result<Option<Packet>> {
         loop {
-            match self.engine_socket.poll() {
+            match self.engine_client.poll() {
                 Ok(Some(packet)) => {
                     if packet.packet_id == EnginePacketId::Message
                         || packet.packet_id == EnginePacketId::MessageBinary
@@ -170,7 +170,7 @@ impl Socket {
             let mut attachments_left = socket_packet.attachment_count;
             let mut attachments = Vec::new();
             while attachments_left > 0 {
-                let next = self.engine_socket.poll();
+                let next = self.engine_client.poll();
                 match next {
                     Err(err) => return Err(err.into()),
                     Ok(Some(packet)) => match packet.packet_id {
@@ -197,6 +197,6 @@ impl Socket {
     }
 
     fn is_engineio_connected(&self) -> Result<bool> {
-        Ok(self.engine_socket.is_connected()?)
+        Ok(self.engine_client.is_connected()?)
     }
 }


### PR DESCRIPTION
Breaking changes:
- renamed socket to client. Left a compatibility shim for now if they were using the import in the crate root.