### PR TITLE
Implement Stream for all engine.io async types and remove poll methods, version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -730,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -743,7 +743,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1344,6 +1344,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/engineio/Cargo.toml
+++ b/engineio/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 base64 = "0.13.0"
 bytes = "1"
 crossbeam-utils = "0.8.6"
-reqwest = { version = "0.11.9", features = ["blocking", "native-tls"] }
+reqwest = { version = "0.11.9", features = ["blocking", "native-tls", "stream"] }
 adler32 = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/engineio/src/asynchronous/async_socket.rs
+++ b/engineio/src/asynchronous/async_socket.rs
@@ -23,7 +23,7 @@ use crate::{
 
 #[derive(Clone)]
 pub struct Socket {
-    pub(super) handle: Handle,
+    handle: Handle,
     transport: Arc<AsyncTransportType>,
     on_close: OptionalCallback<()>,
     on_data: OptionalCallback<Bytes>,

--- a/engineio/src/asynchronous/async_socket.rs
+++ b/engineio/src/asynchronous/async_socket.rs
@@ -1,5 +1,6 @@
 use std::{
     fmt::Debug,
+    pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -7,11 +8,11 @@ use std::{
 };
 
 use bytes::Bytes;
-use tokio::{
-    runtime::Handle,
-    sync::{Mutex, RwLock},
-    time::Instant,
+use futures_util::{
+    stream::{self, once},
+    Stream, StreamExt,
 };
+use tokio::{runtime::Handle, sync::Mutex, time::Instant};
 
 use crate::{
     asynchronous::{callback::OptionalCallback, transport::AsyncTransportType},
@@ -22,7 +23,7 @@ use crate::{
 
 #[derive(Clone)]
 pub struct Socket {
-    handle: Handle,
+    pub(super) handle: Handle,
     transport: Arc<AsyncTransportType>,
     on_close: OptionalCallback<()>,
     on_data: OptionalCallback<Bytes>,
@@ -33,8 +34,6 @@ pub struct Socket {
     last_ping: Arc<Mutex<Instant>>,
     last_pong: Arc<Mutex<Instant>>,
     connection_data: Arc<HandshakePacket>,
-    /// Since we get packets in payloads it's possible to have a state where only some of the packets have been consumed.
-    remaining_packets: Arc<RwLock<Option<crate::packet::IntoIter>>>,
 }
 
 impl Socket {
@@ -59,7 +58,6 @@ impl Socket {
             last_ping: Arc::new(Mutex::new(Instant::now())),
             last_pong: Arc::new(Mutex::new(Instant::now())),
             connection_data: Arc::new(handshake),
-            remaining_packets: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -83,37 +81,45 @@ impl Socket {
         Ok(())
     }
 
-    /// Polls for next payload
-    pub(crate) async fn poll(&self) -> Result<Option<Packet>> {
-        loop {
-            if self.connected.load(Ordering::Acquire) {
-                if self.remaining_packets.read().await.is_some() {
-                    // SAFETY: checked is some above
-                    let mut iter = self.remaining_packets.write().await;
-                    let iter = iter.as_mut().unwrap();
-                    if let Some(packet) = iter.next() {
-                        return Ok(Some(packet));
-                    }
-                }
-
-                // Iterator has run out of packets, get a new payload
-                let data = self.transport.as_transport().poll().await?;
-
-                if data.is_empty() {
-                    continue;
-                }
-
-                let payload = Payload::try_from(data)?;
-                let mut iter = payload.into_iter();
-
-                if let Some(packet) = iter.next() {
-                    *self.remaining_packets.write().await = Some(iter);
-                    return Ok(Some(packet));
-                }
-            } else {
-                return Ok(None);
-            }
+    /// Creates a stream over the incoming packets, uses the streams provided by the
+    /// underlying transport types.
+    pub(crate) async fn stream(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Option<Packet>>> + '_>>> {
+        if !self.connected.load(Ordering::Acquire) {
+            return Err(Error::IllegalActionBeforeOpen());
         }
+
+        // map the byte stream of the underlying transport
+        // to a packet stream
+        let stream = self
+            .transport
+            .as_transport()
+            .stream()
+            .await?
+            .map(move |payload| {
+                // this generator is needed as Rust only allows one right_stream call per closure
+                let error_gen = |err| once(async { Err(err) }).right_stream();
+
+                if let Err(err) = payload {
+                    return error_gen(err);
+                }
+
+                // SAFETY: checked is some above
+                let payload = Payload::try_from(payload.unwrap());
+                if let Err(err) = payload {
+                    return error_gen(err);
+                }
+
+                // SAFETY: checked is some above
+                stream::iter(payload.unwrap().into_iter())
+                    .map(|val| Ok(Some(val)))
+                    .left_stream()
+            });
+
+        // Flatten stream of streams into stream
+        let stream = stream.flatten();
+        Ok(Box::pin(stream))
     }
 
     pub async fn disconnect(&self) -> Result<()> {
@@ -174,21 +180,21 @@ impl Socket {
         *self.last_ping.lock().await = Instant::now();
     }
 
-    pub(crate) async fn handle_packet(&self, packet: Packet) {
+    pub(crate) fn handle_packet(&self, packet: Packet) {
         if let Some(on_packet) = self.on_packet.as_ref() {
             let on_packet = on_packet.clone();
             self.handle.spawn(async move { on_packet(packet).await });
         }
     }
 
-    pub(crate) async fn handle_data(&self, data: Bytes) {
+    pub(crate) fn handle_data(&self, data: Bytes) {
         if let Some(on_data) = self.on_data.as_ref() {
             let on_data = on_data.clone();
             self.handle.spawn(async move { on_data(data).await });
         }
     }
 
-    pub(crate) async fn handle_close(&self) {
+    pub(crate) fn handle_close(&self) {
         if let Some(on_close) = self.on_close.as_ref() {
             let on_close = on_close.clone();
             self.handle.spawn(async move { on_close(()).await });
@@ -212,7 +218,6 @@ impl Debug for Socket {
             .field("last_ping", &self.last_ping)
             .field("last_pong", &self.last_pong)
             .field("connection_data", &self.connection_data)
-            .field("remaining_packets", &self.remaining_packets)
             .finish()
     }
 }

--- a/engineio/src/asynchronous/async_transports/websocket.rs
+++ b/engineio/src/asynchronous/async_transports/websocket.rs
@@ -59,7 +59,7 @@ impl AsyncTransport for WebsocketTransport {
         self.inner.emit(data, is_binary_att).await
     }
 
-    async fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>> {
+    fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>> {
         Ok(Box::pin(self.inner.stream()))
     }
 
@@ -150,8 +150,8 @@ mod test {
                 transport.base_url().await?.to_string()
             )
         );
-        println!("{:?}", transport.stream().await?.next().await.unwrap());
-        println!("{:?}", transport.stream().await?.next().await.unwrap());
+        println!("{:?}", transport.stream()?.next().await.unwrap());
+        println!("{:?}", transport.stream()?.next().await.unwrap());
         Ok(())
     }
 }

--- a/engineio/src/asynchronous/async_transports/websocket_secure.rs
+++ b/engineio/src/asynchronous/async_transports/websocket_secure.rs
@@ -1,10 +1,12 @@
 use std::fmt::Debug;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::asynchronous::transport::AsyncTransport;
 use crate::error::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures_util::Stream;
 use futures_util::StreamExt;
 use http::HeaderMap;
 use native_tls::TlsConnector;
@@ -70,8 +72,8 @@ impl AsyncTransport for WebsocketSecureTransport {
         self.inner.emit(data, is_binary_att).await
     }
 
-    async fn poll(&self) -> Result<Bytes> {
-        self.inner.poll().await
+    async fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>> {
+        Ok(Box::pin(self.inner.stream()))
     }
 
     async fn base_url(&self) -> Result<Url> {

--- a/engineio/src/asynchronous/async_transports/websocket_secure.rs
+++ b/engineio/src/asynchronous/async_transports/websocket_secure.rs
@@ -72,7 +72,7 @@ impl AsyncTransport for WebsocketSecureTransport {
         self.inner.emit(data, is_binary_att).await
     }
 
-    async fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>> {
+    fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>> {
         Ok(Box::pin(self.inner.stream()))
     }
 

--- a/engineio/src/asynchronous/client/async_client.rs
+++ b/engineio/src/asynchronous/client/async_client.rs
@@ -1,7 +1,10 @@
+use std::{future::Future, pin::Pin};
+
 use crate::{
     asynchronous::async_socket::Socket as InnerSocket, error::Result, Error, Packet, PacketId,
 };
 use bytes::Bytes;
+use futures_util::{Stream, StreamExt};
 
 #[derive(Clone, Debug)]
 pub struct Client {
@@ -29,44 +32,53 @@ impl Client {
         self.socket.emit(packet).await
     }
 
-    /// Polls for next payload
     #[doc(hidden)]
-    pub async fn poll(&self) -> Result<Option<Packet>> {
-        let packet = self.socket.poll().await?;
-        if let Some(packet) = packet {
-            // check for the appropriate action or callback
-            self.socket.handle_packet(packet.clone()).await;
-            match packet.packet_id {
-                PacketId::MessageBinary => {
-                    self.socket.handle_data(packet.data.clone()).await;
+    pub async fn stream(
+        &self,
+    ) -> Result<Pin<Box<dyn Stream<Item = impl Future<Output = Result<Option<Packet>>> + '_> + '_>>>
+    {
+        // TODO: is map the right thing? We basically want the sideffects of each packet..
+        let stream = self.socket.stream().await?.map(|item| async {
+            let packet = item?;
+
+            if let Some(packet) = packet {
+                // check for the appropriate action or callback
+                self.socket.handle_packet(packet.clone());
+                match packet.packet_id {
+                    PacketId::MessageBinary => {
+                        self.socket.handle_data(packet.data.clone());
+                    }
+                    PacketId::Message => {
+                        self.socket.handle_data(packet.data.clone());
+                    }
+                    PacketId::Close => {
+                        self.socket.handle_close();
+                    }
+                    PacketId::Open => {
+                        unreachable!("Won't happen as we open the connection beforehand");
+                    }
+                    PacketId::Upgrade => {
+                        // this is already checked during the handshake, so just do nothing here
+                    }
+                    PacketId::Ping => {
+                        // TODO: because of these to lines we need to return a "Future<Output = Stream....>"...
+                        self.socket.pinged().await;
+                        self.emit(Packet::new(PacketId::Pong, Bytes::new())).await?;
+                    }
+                    PacketId::Pong => {
+                        // this will never happen as the pong packet is
+                        // only sent by the client
+                        return Err(Error::InvalidPacket());
+                    }
+                    PacketId::Noop => (),
                 }
-                PacketId::Message => {
-                    self.socket.handle_data(packet.data.clone()).await;
-                }
-                PacketId::Close => {
-                    self.socket.handle_close().await;
-                }
-                PacketId::Open => {
-                    unreachable!("Won't happen as we open the connection beforehand");
-                }
-                PacketId::Upgrade => {
-                    // this is already checked during the handshake, so just do nothing here
-                }
-                PacketId::Ping => {
-                    self.socket.pinged().await;
-                    self.emit(Packet::new(PacketId::Pong, Bytes::new())).await?;
-                }
-                PacketId::Pong => {
-                    // this will never happen as the pong packet is
-                    // only sent by the client
-                    return Err(Error::InvalidPacket());
-                }
-                PacketId::Noop => (),
+                Ok(Some(packet))
+            } else {
+                Ok(None)
             }
-            Ok(Some(packet))
-        } else {
-            Ok(None)
-        }
+        });
+
+        Ok(Box::pin(stream))
     }
 
     /// Check if the underlying transport client is connected.
@@ -80,6 +92,7 @@ mod test {
 
     use super::*;
     use crate::{asynchronous::ClientBuilder, header::HeaderMap, packet::PacketId, Error};
+    use futures_util::StreamExt;
     use native_tls::TlsConnector;
     use url::Url;
 
@@ -95,7 +108,7 @@ mod test {
 
         sut.connect().await?;
 
-        assert!(sut.poll().await.is_ok());
+        assert!(sut.stream().await?.next().await.unwrap().await.is_ok());
 
         assert!(builder(Url::parse("fake://fake.fake").unwrap())
             .build_websocket()
@@ -146,7 +159,7 @@ mod test {
         socket.connect().await.unwrap();
 
         assert_eq!(
-            socket.poll().await?,
+            socket.stream().await?.next().await.unwrap().await?,
             Some(Packet::new(PacketId::Message, "hello client"))
         );
 
@@ -155,7 +168,7 @@ mod test {
             .await?;
 
         assert_eq!(
-            socket.poll().await?,
+            socket.stream().await?.next().await.unwrap().await?,
             Some(Packet::new(PacketId::Message, "Roger Roger"))
         );
 
@@ -172,7 +185,7 @@ mod test {
 
         // hello client
         assert!(matches!(
-            socket.poll().await?,
+            socket.stream().await?.next().await.unwrap().await?,
             Some(Packet {
                 packet_id: PacketId::Message,
                 ..
@@ -180,7 +193,7 @@ mod test {
         ));
         // Ping
         assert!(matches!(
-            socket.poll().await?,
+            socket.stream().await?.next().await.unwrap().await?,
             Some(Packet {
                 packet_id: PacketId::Ping,
                 ..

--- a/engineio/src/asynchronous/client/builder.rs
+++ b/engineio/src/asynchronous/client/builder.rs
@@ -121,8 +121,7 @@ impl ClientBuilder {
 
         let handshake: HandshakePacket = Packet::try_from(
             transport
-                .stream()
-                .await?
+                .stream()?
                 .next()
                 .await
                 .ok_or(Error::IncompletePacket())??,

--- a/engineio/src/asynchronous/client/builder.rs
+++ b/engineio/src/asynchronous/client/builder.rs
@@ -11,7 +11,7 @@ use crate::{
     Error, Packet, ENGINE_IO_VERSION,
 };
 use bytes::Bytes;
-use futures_util::future::BoxFuture;
+use futures_util::{future::BoxFuture, StreamExt};
 use native_tls::TlsConnector;
 use url::Url;
 
@@ -119,7 +119,15 @@ impl ClientBuilder {
 
         let mut url = self.url.clone();
 
-        let handshake: HandshakePacket = Packet::try_from(transport.poll().await?)?.try_into()?;
+        let handshake: HandshakePacket = Packet::try_from(
+            transport
+                .stream()
+                .await?
+                .next()
+                .await
+                .ok_or(Error::IncompletePacket())??,
+        )?
+        .try_into()?;
 
         // update the base_url with the new sid
         url.query_pairs_mut().append_pair("sid", &handshake.sid[..]);

--- a/engineio/src/asynchronous/transport.rs
+++ b/engineio/src/asynchronous/transport.rs
@@ -2,7 +2,8 @@ use crate::error::Result;
 use adler32::adler32;
 use async_trait::async_trait;
 use bytes::Bytes;
-use std::time::SystemTime;
+use futures_util::Stream;
+use std::{pin::Pin, time::SystemTime};
 use url::Url;
 
 use super::async_transports::{PollingTransport, WebsocketSecureTransport, WebsocketTransport};
@@ -13,10 +14,9 @@ pub trait AsyncTransport {
     /// socketio binary attachment via the boolean attribute `is_binary_att`.
     async fn emit(&self, data: Bytes, is_binary_att: bool) -> Result<()>;
 
-    /// Performs the server long polling procedure as long as the client is
-    /// connected. This should run separately at all time to ensure proper
-    /// response handling from the server.
-    async fn poll(&self) -> Result<Bytes>;
+    /// Returns a stream over the underlying incoming bytes.
+    /// Can't use
+    async fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>>;
 
     /// Returns start of the url. ex. http://localhost:2998/engine.io/?EIO=4&transport=polling
     /// Must have EIO and transport already set.

--- a/engineio/src/asynchronous/transport.rs
+++ b/engineio/src/asynchronous/transport.rs
@@ -16,7 +16,7 @@ pub trait AsyncTransport {
 
     /// Returns a stream over the underlying incoming bytes.
     /// Can't use
-    async fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>>;
+    fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>>;
 
     /// Returns start of the url. ex. http://localhost:2998/engine.io/?EIO=4&transport=polling
     /// Must have EIO and transport already set.

--- a/engineio/src/transports/websocket.rs
+++ b/engineio/src/transports/websocket.rs
@@ -49,8 +49,7 @@ impl Transport for WebsocketTransport {
     fn poll(&self) -> Result<Bytes> {
         self.runtime.block_on(async {
             self.inner
-                .stream()
-                .await?
+                .stream()?
                 .next()
                 .await
                 .ok_or(Error::IncompletePacket())?

--- a/engineio/src/transports/websocket_secure.rs
+++ b/engineio/src/transports/websocket_secure.rs
@@ -57,8 +57,7 @@ impl Transport for WebsocketSecureTransport {
     fn poll(&self) -> Result<Bytes> {
         self.runtime.block_on(async {
             self.inner
-                .stream()
-                .await?
+                .stream()?
                 .next()
                 .await
                 .ok_or(Error::IncompletePacket())?

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -91,7 +91,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Registers a new callback for a certain [`socketio::event::Event`]. The event could either be
+    /// Registers a new callback for a certain [`crate::event::Event`]. The event could either be
     /// one of the common events like `message`, `error`, `connect`, `close` or a custom
     /// event defined by a string, e.g. `onPayment` or `foo`.
     ///


### PR DESCRIPTION
This is an alternative implementation to #154, that does not implement stream for every type but rather provides a method `stream` on every type that returns a stream.
The stream is mapped on every layer (from acquiring the bytes to parsing packets).
~~The issue with this implementation is the return type of the `Client`s stream method, as this returns a stream of futures which is verbose to handle~~ nvm, I found the `then` method that allows an async context.

I also sticked to reqwest, as tls handling in hyper is quite complicated and reqwest delivers a clean API for configuring a client.