### PR TITLE
ci: bump engine.io-js dependency version

### DIFF
--- a/ci/package.json
+++ b/ci/package.json
@@ -5,7 +5,7 @@
   "author": "Bastian Kersting",
   "license": "MIT",
   "dependencies": {
-    "engine.io": "5.0.0",
+    "engine.io": "5.2.1",
     "socket.io": "4.0.0"
   }
 }


### PR DESCRIPTION
This is done due to a security alert, for more information visit: https://github.com/advisories/GHSA-273r-mgr4-v34f