### PR TITLE
refactor: change `stream` implementation in engine.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1373,7 @@ name = "rust_engineio"
 version = "0.3.1"
 dependencies = [
  "adler32",
+ "async-stream",
  "async-trait",
  "base64",
  "bytes",

--- a/engineio/Cargo.toml
+++ b/engineio/Cargo.toml
@@ -24,6 +24,7 @@ tungstenite = "0.17.2"
 tokio = "1.16.1"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 async-trait = "0.1.51"
+async-stream = "0.3.3"
 thiserror = "1.0"
 native-tls = "0.2.10"
 url = "2.2.2"

--- a/engineio/src/asynchronous/async_socket.rs
+++ b/engineio/src/asynchronous/async_socket.rs
@@ -97,9 +97,6 @@ impl Socket {
             PacketId::Close => {
                 self.handle_close();
             }
-            PacketId::Open => {
-                unreachable!("Won't happen as we open the connection beforehand");
-            }
             PacketId::Upgrade => {
                 // this is already checked during the handshake, so just do nothing here
             }
@@ -107,9 +104,9 @@ impl Socket {
                 self.pinged().await;
                 self.emit(Packet::new(PacketId::Pong, Bytes::new())).await?;
             }
-            PacketId::Pong => {
-                // this will never happen as the pong packet is
-                // only sent by the client
+            PacketId::Pong | PacketId::Open => {
+                // this will never happen as the pong and open
+                // packets are only sent by the client
                 return Err(Error::InvalidPacket());
             }
             PacketId::Noop => (),

--- a/engineio/src/asynchronous/async_transports/polling.rs
+++ b/engineio/src/asynchronous/async_transports/polling.rs
@@ -12,7 +12,7 @@ use std::{pin::Pin, sync::Arc};
 use tokio::sync::{Mutex, RwLock};
 use url::Url;
 
-use crate::asynchronous::generator::SyncSendGenerator;
+use crate::asynchronous::generator::Generator;
 use crate::{asynchronous::transport::AsyncTransport, error::Result, Error};
 
 /// An asynchronous polling type. Makes use of the nonblocking reqwest types and
@@ -21,7 +21,7 @@ use crate::{asynchronous::transport::AsyncTransport, error::Result, Error};
 pub struct PollingTransport {
     client: Client,
     base_url: Arc<RwLock<Url>>,
-    generator: Arc<Mutex<SyncSendGenerator<Result<Bytes>>>>,
+    generator: Arc<Mutex<Generator<Result<Bytes>>>>,
 }
 
 impl PollingTransport {
@@ -74,7 +74,7 @@ impl PollingTransport {
     fn stream(
         url: Url,
         client: Client,
-    ) -> Pin<Box<dyn Stream<Item = Result<Bytes>> + 'static + Send + Sync>> {
+    ) -> Pin<Box<dyn Stream<Item = Result<Bytes>> + 'static + Send>> {
         Box::pin(try_stream! {
             loop {
                 for await elem in Self::send_request(url.clone(), client.clone()) {

--- a/engineio/src/asynchronous/async_transports/polling.rs
+++ b/engineio/src/asynchronous/async_transports/polling.rs
@@ -154,7 +154,6 @@ impl Debug for PollingTransport {
         f.debug_struct("PollingTransport")
             .field("client", &self.client)
             .field("base_url", &self.base_url)
-            .field("generator", &"")
             .finish()
     }
 }

--- a/engineio/src/asynchronous/async_transports/websocket.rs
+++ b/engineio/src/asynchronous/async_transports/websocket.rs
@@ -60,8 +60,8 @@ impl AsyncTransport for WebsocketTransport {
         self.inner.emit(data, is_binary_att).await
     }
 
-    fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>> {
-        Ok(Box::pin(self.inner.stream()))
+    fn stream(&self) -> Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>> {
+        Box::pin(self.inner.stream())
     }
 
     async fn base_url(&self) -> Result<Url> {
@@ -151,8 +151,8 @@ mod test {
                 transport.base_url().await?.to_string()
             )
         );
-        println!("{:?}", transport.stream()?.next().await.unwrap());
-        println!("{:?}", transport.stream()?.next().await.unwrap());
+        println!("{:?}", transport.stream().next().await.unwrap());
+        println!("{:?}", transport.stream().next().await.unwrap());
         Ok(())
     }
 }

--- a/engineio/src/asynchronous/async_transports/websocket.rs
+++ b/engineio/src/asynchronous/async_transports/websocket.rs
@@ -19,6 +19,7 @@ use super::websocket_general::AsyncWebsocketGeneralTransport;
 /// An asynchronous websocket transport type.
 /// This type only allows for plain websocket
 /// connections ("ws://").
+#[derive(Clone)]
 pub struct WebsocketTransport {
     inner: AsyncWebsocketGeneralTransport,
     base_url: Arc<RwLock<Url>>,
@@ -60,10 +61,6 @@ impl AsyncTransport for WebsocketTransport {
         self.inner.emit(data, is_binary_att).await
     }
 
-    fn stream(&self) -> Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>> {
-        Box::pin(self.inner.stream())
-    }
-
     async fn base_url(&self) -> Result<Url> {
         Ok(self.base_url.read().await.clone())
     }
@@ -79,6 +76,17 @@ impl AsyncTransport for WebsocketTransport {
         url.set_scheme("ws").unwrap();
         *self.base_url.write().await = url;
         Ok(())
+    }
+}
+
+impl Stream for WebsocketTransport {
+    type Item = Result<Bytes>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
     }
 }
 
@@ -143,7 +151,7 @@ mod test {
 
     #[tokio::test]
     async fn websocket_secure_debug() -> Result<()> {
-        let transport = new().await?;
+        let mut transport = new().await?;
         assert_eq!(
             format!("{:?}", transport),
             format!(
@@ -151,8 +159,8 @@ mod test {
                 transport.base_url().await?.to_string()
             )
         );
-        println!("{:?}", transport.stream().next().await.unwrap());
-        println!("{:?}", transport.stream().next().await.unwrap());
+        println!("{:?}", transport.next().await.unwrap());
+        println!("{:?}", transport.next().await.unwrap());
         Ok(())
     }
 }

--- a/engineio/src/asynchronous/async_transports/websocket_general.rs
+++ b/engineio/src/asynchronous/async_transports/websocket_general.rs
@@ -90,7 +90,7 @@ impl Stream for AsyncWebsocketGeneralTransport {
         lock.poll_next_unpin(cx)
             .map(|option| {
                 option.map(|result| {
-                    result.map(|msg|
+                    result.map(|msg| {
                         if msg.is_binary() {
                             let data = msg.into_data();
                             let mut msg = BytesMut::with_capacity(data.len() + 1);
@@ -103,11 +103,11 @@ impl Stream for AsyncWebsocketGeneralTransport {
                         } else {
                             // in the edge case of a packet with a type other than text
                             // or binary map it to an empty packet.
-                            // this always needs to get filtered out 
+                            // this always needs to get filtered out
                             // by the user of the stream
                             Bytes::new()
                         }
-                    )
+                    })
                 })
             })
             .map_err(Error::WebsocketError)

--- a/engineio/src/asynchronous/async_transports/websocket_general.rs
+++ b/engineio/src/asynchronous/async_transports/websocket_general.rs
@@ -1,10 +1,11 @@
 use std::{borrow::Cow, str::from_utf8, sync::Arc};
 
 use crate::{error::Result, Error, Packet, PacketId};
+use async_stream::try_stream;
 use bytes::{BufMut, Bytes, BytesMut};
 use futures_util::{
     stream::{SplitSink, SplitStream},
-    FutureExt, SinkExt, Stream, StreamExt,
+    SinkExt, Stream, StreamExt,
 };
 use tokio::{net::TcpStream, sync::Mutex};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
@@ -73,25 +74,29 @@ impl AsyncWebsocketGeneralTransport {
         Ok(())
     }
 
-    pub(crate) fn stream(&self) -> impl Stream<Item = Result<Bytes>> + '_ {
-        self.receiver
-            .lock()
-            .into_stream()
-            .then(|mut rec| async move {
-                loop {
-                    let msg = rec.next().await.ok_or(Error::IncompletePacket())??;
-                    // only propagate binary and text messages
-                    if msg.is_binary() {
-                        let data = msg.into_data();
-                        let mut msg = BytesMut::with_capacity(data.len() + 1);
-                        msg.put_u8(PacketId::Message as u8);
-                        msg.put(data.as_ref());
+    fn receive_message(&self) -> impl Stream<Item = Result<Message>> + '_ {
+        try_stream! {
+            for await item in &mut *self.receiver.lock().await {
+                yield item?;
+            }
+        }
+    }
 
-                        return Ok(msg.freeze());
-                    } else if msg.is_text() {
-                        return Ok(Bytes::from(msg.into_data()));
-                    }
+    pub(crate) fn stream(&self) -> impl Stream<Item = Result<Bytes>> + '_ {
+        try_stream! {
+            for await msg in self.receive_message() {
+                let msg = msg?;
+                if msg.is_binary() {
+                    let data = msg.into_data();
+                    let mut msg = BytesMut::with_capacity(data.len() + 1);
+                    msg.put_u8(PacketId::Message as u8);
+                    msg.put(data.as_ref());
+
+                    yield msg.freeze();
+                } else {
+                    yield Bytes::from(msg.into_data());
                 }
-            })
+            }
+        }
     }
 }

--- a/engineio/src/asynchronous/async_transports/websocket_secure.rs
+++ b/engineio/src/asynchronous/async_transports/websocket_secure.rs
@@ -21,6 +21,7 @@ use super::websocket_general::AsyncWebsocketGeneralTransport;
 /// An asynchronous websocket transport type.
 /// This type only allows for secure websocket
 /// connections ("wss://").
+#[derive(Clone)]
 pub struct WebsocketSecureTransport {
     inner: AsyncWebsocketGeneralTransport,
     base_url: Arc<RwLock<Url>>,
@@ -63,14 +64,21 @@ impl WebsocketSecureTransport {
     }
 }
 
+impl Stream for WebsocketSecureTransport {
+    type Item = Result<Bytes>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
 #[async_trait]
 impl AsyncTransport for WebsocketSecureTransport {
     async fn emit(&self, data: Bytes, is_binary_att: bool) -> Result<()> {
         self.inner.emit(data, is_binary_att).await
-    }
-
-    fn stream(&self) -> Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>> {
-        Box::pin(self.inner.stream())
     }
 
     async fn base_url(&self) -> Result<Url> {

--- a/engineio/src/asynchronous/async_transports/websocket_secure.rs
+++ b/engineio/src/asynchronous/async_transports/websocket_secure.rs
@@ -69,8 +69,8 @@ impl AsyncTransport for WebsocketSecureTransport {
         self.inner.emit(data, is_binary_att).await
     }
 
-    fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>> {
-        Ok(Box::pin(self.inner.stream()))
+    fn stream(&self) -> Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>> {
+        Box::pin(self.inner.stream())
     }
 
     async fn base_url(&self) -> Result<Url> {

--- a/engineio/src/asynchronous/client/async_client.rs
+++ b/engineio/src/asynchronous/client/async_client.rs
@@ -1,4 +1,4 @@
-use std::{pin::Pin, sync::Arc};
+use std::{fmt::Debug, pin::Pin, sync::Arc};
 
 use crate::{
     asynchronous::{async_socket::Socket as InnerSocket, generator::Generator},
@@ -69,6 +69,14 @@ impl Stream for Client {
     ) -> std::task::Poll<Option<Self::Item>> {
         let mut lock = ready!(Box::pin(self.generator.lock()).poll_unpin(cx));
         lock.poll_next_unpin(cx)
+    }
+}
+
+impl Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("socket", &self.socket)
+            .finish()
     }
 }
 

--- a/engineio/src/asynchronous/client/async_client.rs
+++ b/engineio/src/asynchronous/client/async_client.rs
@@ -44,7 +44,9 @@ impl Client {
     }
 
     /// Static method that returns a generator for each element of the stream.
-    fn stream(socket: InnerSocket) -> Pin<Box<impl Stream<Item = Result<Packet>> + 'static>> {
+    fn stream(
+        socket: InnerSocket,
+    ) -> Pin<Box<impl Stream<Item = Result<Packet>> + 'static + Send>> {
         Box::pin(try_stream! {
             for await item in socket.clone() {
                 let packet = item?;

--- a/engineio/src/asynchronous/client/builder.rs
+++ b/engineio/src/asynchronous/client/builder.rs
@@ -121,7 +121,7 @@ impl ClientBuilder {
 
         let handshake: HandshakePacket = Packet::try_from(
             transport
-                .stream()?
+                .stream()
                 .next()
                 .await
                 .ok_or(Error::IncompletePacket())??,

--- a/engineio/src/asynchronous/generator.rs
+++ b/engineio/src/asynchronous/generator.rs
@@ -2,5 +2,6 @@ use std::pin::Pin;
 
 use futures_util::Stream;
 
-pub(crate) type SyncSendGenerator<T> = Pin<Box<dyn Stream<Item = T> + 'static + Send + Sync>>;
-pub(crate) type Generator<T> = Pin<Box<dyn Stream<Item = T> + 'static>>;
+/// A generator is an internal type that represents a [`Send`] [`futures_util::Stream`]
+/// that yields a certain type `T` whenever it's polled.
+pub(crate) type Generator<T> = Pin<Box<dyn Stream<Item = T> + 'static + Send>>;

--- a/engineio/src/asynchronous/generator.rs
+++ b/engineio/src/asynchronous/generator.rs
@@ -1,0 +1,6 @@
+use std::pin::Pin;
+
+use futures_util::Stream;
+
+pub(crate) type SyncSendGenerator<T> = Pin<Box<dyn Stream<Item = T> + 'static + Send + Sync>>;
+pub(crate) type Generator<T> = Pin<Box<dyn Stream<Item = T> + 'static>>;

--- a/engineio/src/asynchronous/mod.rs
+++ b/engineio/src/asynchronous/mod.rs
@@ -7,6 +7,8 @@ pub(self) mod async_socket;
 mod callback;
 #[cfg(feature = "async")]
 pub mod client;
+#[cfg(feature = "async")]
+mod generator;
 
 #[cfg(feature = "async")]
 pub use client::{Client, ClientBuilder};

--- a/engineio/src/asynchronous/transport.rs
+++ b/engineio/src/asynchronous/transport.rs
@@ -61,7 +61,7 @@ impl From<WebsocketSecureTransport> for AsyncTransportType {
 
 #[cfg(feature = "async")]
 impl AsyncTransportType {
-    pub fn as_transport(&self) -> &dyn AsyncTransport {
+    pub fn as_transport(&self) -> &(dyn AsyncTransport + Send) {
         match self {
             AsyncTransportType::Polling(transport) => transport,
             AsyncTransportType::Websocket(transport) => transport,
@@ -69,7 +69,7 @@ impl AsyncTransportType {
         }
     }
 
-    pub fn as_pin_box(&mut self) -> Pin<Box<&mut dyn AsyncTransport>> {
+    pub fn as_pin_box(&mut self) -> Pin<Box<&mut (dyn AsyncTransport + Send)>> {
         match self {
             AsyncTransportType::Polling(transport) => Box::pin(transport),
             AsyncTransportType::Websocket(transport) => Box::pin(transport),

--- a/engineio/src/asynchronous/transport.rs
+++ b/engineio/src/asynchronous/transport.rs
@@ -16,7 +16,7 @@ pub trait AsyncTransport {
 
     /// Returns a stream over the underlying incoming bytes.
     /// Can't use
-    fn stream(&self) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>>;
+    fn stream(&self) -> Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>;
 
     /// Returns start of the url. ex. http://localhost:2998/engine.io/?EIO=4&transport=polling
     /// Must have EIO and transport already set.

--- a/engineio/src/asynchronous/transport.rs
+++ b/engineio/src/asynchronous/transport.rs
@@ -9,14 +9,10 @@ use url::Url;
 use super::async_transports::{PollingTransport, WebsocketSecureTransport, WebsocketTransport};
 
 #[async_trait]
-pub trait AsyncTransport {
+pub trait AsyncTransport: Stream<Item = Result<Bytes>> + Unpin {
     /// Sends a packet to the server. This optionally handles sending of a
     /// socketio binary attachment via the boolean attribute `is_binary_att`.
     async fn emit(&self, data: Bytes, is_binary_att: bool) -> Result<()>;
-
-    /// Returns a stream over the underlying incoming bytes.
-    /// Can't use
-    fn stream(&self) -> Pin<Box<dyn Stream<Item = Result<Bytes>> + '_>>;
 
     /// Returns start of the url. ex. http://localhost:2998/engine.io/?EIO=4&transport=polling
     /// Must have EIO and transport already set.
@@ -38,7 +34,7 @@ pub trait AsyncTransport {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum AsyncTransportType {
     Polling(PollingTransport),
     Websocket(WebsocketTransport),
@@ -70,6 +66,14 @@ impl AsyncTransportType {
             AsyncTransportType::Polling(transport) => transport,
             AsyncTransportType::Websocket(transport) => transport,
             AsyncTransportType::WebsocketSecure(transport) => transport,
+        }
+    }
+
+    pub fn as_pin_box(&mut self) -> Pin<Box<&mut dyn AsyncTransport>> {
+        match self {
+            AsyncTransportType::Polling(transport) => Box::pin(transport),
+            AsyncTransportType::Websocket(transport) => Box::pin(transport),
+            AsyncTransportType::WebsocketSecure(transport) => Box::pin(transport),
         }
     }
 }

--- a/engineio/src/transports/websocket.rs
+++ b/engineio/src/transports/websocket.rs
@@ -10,13 +10,13 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use http::HeaderMap;
 use std::sync::Arc;
-use tokio::runtime::Runtime;
+use tokio::{runtime::Runtime, sync::Mutex};
 use url::Url;
 
 #[derive(Clone)]
 pub struct WebsocketTransport {
     runtime: Arc<Runtime>,
-    inner: Arc<AsyncWebsocketTransport>,
+    inner: Arc<Mutex<AsyncWebsocketTransport>>,
 }
 
 impl WebsocketTransport {
@@ -30,38 +30,47 @@ impl WebsocketTransport {
 
         Ok(WebsocketTransport {
             runtime: Arc::new(runtime),
-            inner: Arc::new(inner),
+            inner: Arc::new(Mutex::new(inner)),
         })
     }
 
     /// Sends probe packet to ensure connection is valid, then sends upgrade
     /// request
     pub(crate) fn upgrade(&self) -> Result<()> {
-        self.runtime.block_on(self.inner.upgrade())
+        self.runtime.block_on(async {
+            let lock = self.inner.lock().await;
+            lock.upgrade().await
+        })
     }
 }
 
 impl Transport for WebsocketTransport {
     fn emit(&self, data: Bytes, is_binary_att: bool) -> Result<()> {
-        self.runtime.block_on(self.inner.emit(data, is_binary_att))
+        self.runtime.block_on(async {
+            let lock = self.inner.lock().await;
+            lock.emit(data, is_binary_att).await
+        })
     }
 
     fn poll(&self) -> Result<Bytes> {
         self.runtime.block_on(async {
-            self.inner
-                .stream()
-                .next()
-                .await
-                .ok_or(Error::IncompletePacket())?
+            let mut lock = self.inner.lock().await;
+            lock.next().await.ok_or(Error::IncompletePacket())?
         })
     }
 
     fn base_url(&self) -> Result<url::Url> {
-        self.runtime.block_on(self.inner.base_url())
+        self.runtime.block_on(async {
+            let lock = self.inner.lock().await;
+            lock.base_url().await
+        })
     }
 
     fn set_base_url(&self, url: url::Url) -> Result<()> {
-        self.runtime.block_on(self.inner.set_base_url(url))
+        self.runtime.block_on(async {
+            let lock = self.inner.lock().await;
+            lock.set_base_url(url).await
+        })
     }
 }
 

--- a/engineio/src/transports/websocket.rs
+++ b/engineio/src/transports/websocket.rs
@@ -49,7 +49,7 @@ impl Transport for WebsocketTransport {
     fn poll(&self) -> Result<Bytes> {
         self.runtime.block_on(async {
             self.inner
-                .stream()?
+                .stream()
                 .next()
                 .await
                 .ok_or(Error::IncompletePacket())?

--- a/engineio/src/transports/websocket_secure.rs
+++ b/engineio/src/transports/websocket_secure.rs
@@ -57,7 +57,7 @@ impl Transport for WebsocketSecureTransport {
     fn poll(&self) -> Result<Bytes> {
         self.runtime.block_on(async {
             self.inner
-                .stream()?
+                .stream()
                 .next()
                 .await
                 .ok_or(Error::IncompletePacket())?

--- a/socketio/src/client/client.rs
+++ b/socketio/src/client/client.rs
@@ -304,7 +304,7 @@ impl Client {
     #[inline]
     fn handle_binary_event(&self, packet: &Packet) -> Result<()> {
         let event = if let Some(string_data) = &packet.data {
-            string_data.replace("\"", "").into()
+            string_data.replace('\"', " ").into()
         } else {
             Event::Message
         };

--- a/socketio/src/client/client.rs
+++ b/socketio/src/client/client.rs
@@ -304,7 +304,7 @@ impl Client {
     #[inline]
     fn handle_binary_event(&self, packet: &Packet) -> Result<()> {
         let event = if let Some(string_data) = &packet.data {
-            string_data.replace('\"', " ").into()
+            string_data.replace('\"', "").into()
         } else {
             Event::Message
         };


### PR DESCRIPTION
This PR changes the `stream` implementation and usage in the engine.io trait. Earlier PRs introduced async Streams in engine.io but the ergonomics were quite difficult and the implementation was hard to understand. This is changed in this PR, with the introduction of [`async_stream`](https://docs.rs/async-stream/0.3.3/async_stream/index.html), a crate that exposes a handy `try_stream!` macro for writing async generators that implement `futures_util::Stream`.

The changes made here leave some open questions on how sound the generator implementation actually is. Especially for the long polling case, the following issue arises: 
https://github.com/1c3t3a/rust-socketio/blob/a643468d2bf5b7e6db870264ce62e1c6b526377f/engineio/src/asynchronous/async_transports/polling.rs#L96-L119

A solution would be to use something like [`stream_cancel`](https://docs.rs/stream-cancel/0.8.1/stream_cancel/index.html) which wraps a stream and makes it cancelable from outside the stream. 

From my understanding the websocket generator should be sound. It uses a `Mutex` and each generator (spawned by a call to `client.stream()`) works on the same websocket client. The websocket stream is done as soon as the connection to the server is properly closed. An open issue might be that the locking implementation with the `Mutex` might lead to unperformant polling in case many generators want to access the same data.

Until this issue is resolved, I am marking this PR as a Draft PR.