### PR TITLE
Add a GitHub action that runs an engineio benchmark

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,12 @@ name: benchmark engine.io
 jobs:
   runBenchmark:
     name: run benchmark
-    if: contains(github.event.comment.html_url, '/pull/') && contains(github.event.comment.body, '/benchmark')
+    if: contains(github.event.comment.html_url, '/pull/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - uses: boa-dev/criterion-compare-action@v3.2.0
+        if: contains(github.event.comment.body, '/benchmark')
         with:
           cwd: "engineio"
           branchName: ${{ github.base_ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,12 @@
-on: [pull_request]
+on:
+  issue_comment:                                     
+    types: [created, edited, deleted]
 
 name: benchmark engine.io
 jobs:
   runBenchmark:
     name: run benchmark
+    if: contains(github.event.comment.html_url, '/pull/') && contains(github.event.comment.body, '/benchmark')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: boa-dev/criterion-compare-action@v3.0.0
+      - uses: boa-dev/criterion-compare-action@v3.2.0
         with:
           cwd: "engineio"
           branchName: ${{ github.base_ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+on: [pull_request]
+
+name: benchmark engine.io
+jobs:
+  runBenchmark:
+    name: run benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: boa-dev/criterion-compare-action@v3.0.0
+        with:
+          cwd: "engineio"
+          branchName: ${{ github.base_ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,27 @@
 on:
-  issue_comment:                                     
-    types: [created, edited, deleted]
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
 
 name: benchmark engine.io
 jobs:
+
   runBenchmark:
     name: run benchmark
-    if: contains(github.event.comment.html_url, '/pull/')
+    
     runs-on: ubuntu-latest
     steps:
+      - uses: khan/pull-request-comment-trigger@master
+        id: check
+        with:
+          trigger: '@benchmark'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@master
       - uses: boa-dev/criterion-compare-action@v3.2.0
-        if: contains(github.event.comment.body, '/benchmark')
+        if: steps.check.outputs.triggered == 'true'
         with:
           cwd: "engineio"
           branchName: ${{ github.base_ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,3 +11,4 @@ jobs:
         with:
           cwd: "engineio"
           branchName: ${{ github.base_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I want to give this a try. It might be the case that this doesn't run reliable in a GitHub action environment. If that is the case we could remove the action again.