### PR TITLE
fix!: incorrect json parsing in ClientBuilder.auth

### DIFF
--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -216,8 +216,8 @@ impl ClientBuilder {
     ///     .expect("Connection error");
     ///
     /// ```
-    pub fn auth<T: Into<serde_json::Value>>(mut self, auth: T) -> Self {
-        self.auth = Some(auth.into());
+    pub fn auth(mut self, auth: serde_json::Value) -> Self {
+        self.auth = Some(auth);
 
         self
     }


### PR DESCRIPTION
`Into<serde_json::Value>` always converts string to `serde_json::Value::String("...")`.

The following test fails, because One gets parsed as an Object, while the string gets converted into `serde_json::Value::String` 
```rs
#[test]
fn json_compare_test() {
  let using_macro = serde_json::json!({
    "hello": "world"
  });
  let using_into: serde_json::Value = "{ \"hello\": \"world\" }".into();

  assert_eq!(using_into, using_macro)
}
```
![Failed assert_eq](https://user-images.githubusercontent.com/73162071/168997476-034fd880-0ec8-4ed7-bebb-ae7a1bd0eed8.png)  
  
[`serde_json::from_str`](https://docs.serde.rs/serde_json/fn.from_str.html) could be used, but that would mean the method would need to use `Into<String>` as a parameter, which I think would be annoying, as most common use case of this method is using json!() in the method's args.
```rs
let socket = ClientBuilder::new("http://localhost:4204/")
  .namespace("/admin")
  .auth(json!({ "password": "1337" }))
  .on("error", |err, _| eprintln!("Error: {:#?}", err))
  .connect()
  .expect("Connection error");
```