### PR TITLE
chore: add server for restart test

### DIFF
--- a/ci/socket-io-restart.js
+++ b/ci/socket-io-restart.js
@@ -1,0 +1,25 @@
+let createServer = require('http').createServer;
+let server = createServer();
+const io = require('socket.io')(server);
+const port = 4205;
+const timeout = 2000;
+
+
+console.log('Started');
+var callback = client => {
+    console.log('Connected!');
+    client.on('restart_server', () => {
+        console.log('will restart in ', timeout, 'ms');
+        io.close();
+        setTimeout(() => {
+            console.log("do restart")
+            server = createServer();
+            server.listen(port);
+            io.attach(server);
+        }, timeout)
+    });
+};
+io.on('connection', callback);
+io.of('/admin').on('connection', callback);
+// the socket.io client runs on port 4201
+server.listen(port);

--- a/ci/start_test_server.sh
+++ b/ci/start_test_server.sh
@@ -31,6 +31,14 @@ if [ $status -ne 0 ]; then
 fi
 echo "Successfully started socket.io auth instance"
 
+DEBUG=* node socket-io-restart.js &
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Failed to start socket.io-restart: $status"
+  exit $status
+fi
+echo "Successfully started socket.io-restart instance"
+
 DEBUG=* node engine-io-secure.js &
 status=$?
 if [ $status -ne 0 ]; then


### PR DESCRIPTION
Create a new socket.io node server for restart testing.
the restart will make other case failed if add restart logic the `socket-io.js` 