### PR TITLE
feat: emit multipe parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,7 @@ dependencies = [
  "rand",
  "regex",
  "rust_engineio",
+ "serde",
  "serde_json",
  "thiserror",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "rust_engineio"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "adler32",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ use std::time::Duration;
 // socket to communicate with the server
 let callback = |payload: Payload, socket: RawClient| {
        match payload {
-           Payload::String(str) => println!("Received: {}", str),
+           Payload::Json(data) => println!("Received {:?}", data),
            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+           Payload::Multi(vec) => println!("Received multi: {:?}", vec),
+           _ => {}
        }
        socket.emit("test", json!({"got ack": true})).expect("Server unreachable")
 };

--- a/ci/socket-io.js
+++ b/ci/socket-io.js
@@ -39,7 +39,7 @@ var callback = client => {
     client.emit('Hello from the message event!');
     client.emit('test', 'Hello from the test event!');
     client.emit(Buffer.from([4, 5, 6]));
-    client.emit('test', Buffer.from([1, 2, 3]));
+    client.emit('test', Buffer.from([1, 2, 3]), "4", Buffer.from([5, 6]));
 };
 io.on('connection', callback);
 io.of('/admin').on('connection', callback);

--- a/socketio/Cargo.toml
+++ b/socketio/Cargo.toml
@@ -7,7 +7,11 @@ description = "An implementation of a socketio client written in rust."
 readme = "../README.md"
 repository = "https://github.com/1c3t3a/rust-socketio"
 keywords = ["socketio", "engineio", "network", "protocol", "client"]
-categories = ["network-programming", "web-programming", "web-programming::websocket"]
+categories = [
+  "network-programming",
+  "web-programming",
+  "web-programming::websocket",
+]
 license = "MIT"
 
 [dependencies]
@@ -18,6 +22,7 @@ backoff = "0.4"
 rand = "0.8.5"
 crossbeam-utils = "0.8.12"
 adler32 = "1.2.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 regex = "1.6.0"
 byte = "0.2.4"

--- a/socketio/examples/callback.rs
+++ b/socketio/examples/callback.rs
@@ -11,8 +11,10 @@ fn main() {
     // socket to communicate with the server
     let handle_test = |payload: Payload, socket: RawClient| {
         match payload {
-            Payload::String(str) => println!("Received string: {}", str),
+            Payload::Json(json) => println!("Received string: {:?}", json),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+            Payload::Multi(vec_data) => println!("Received vec: {:?}", vec_data),
+            _ => {}
         }
         socket
             .emit("test", json!({"got ack": true}))

--- a/socketio/examples/callback.rs
+++ b/socketio/examples/callback.rs
@@ -13,7 +13,6 @@ fn main() {
         match payload {
             Payload::String(str) => println!("Received string: {}", str),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
-            Payload::Number(num) => println!("Received number: {}", num),
         }
         socket
             .emit_multi("test", vec![json!({"got ack": true})])

--- a/socketio/examples/callback.rs
+++ b/socketio/examples/callback.rs
@@ -13,9 +13,10 @@ fn main() {
         match payload {
             Payload::String(str) => println!("Received string: {}", str),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+            Payload::Number(num) => println!("Received number: {}", num),
         }
         socket
-            .emit("test", json!({"got ack": true}))
+            .emit_multi("test", vec![json!({"got ack": true})])
             .expect("Server unreachable")
     };
 

--- a/socketio/examples/callback.rs
+++ b/socketio/examples/callback.rs
@@ -15,7 +15,7 @@ fn main() {
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
         }
         socket
-            .emit_multi("test", vec![json!({"got ack": true})])
+            .emit("test", json!({"got ack": true}))
             .expect("Server unreachable")
     };
 

--- a/socketio/examples/readme.rs
+++ b/socketio/examples/readme.rs
@@ -8,8 +8,10 @@ fn main() {
     // socket to communicate with the server
     let callback = |payload: Payload, socket: RawClient| {
         match payload {
-            Payload::String(str) => println!("Received: {}", str),
+            Payload::Json(data) => println!("Received: {:?}", data),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+            Payload::Multi(vec_data) => println!("Received vec: {:?}", vec_data),
+            _ => {}
         }
         socket
             .emit("test", json!({"got ack": true}))

--- a/socketio/examples/readme.rs
+++ b/socketio/examples/readme.rs
@@ -10,7 +10,6 @@ fn main() {
         match payload {
             Payload::String(str) => println!("Received: {}", str),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
-            Payload::Number(num) => println!("Received: {}", num),
         }
         socket
             .emit("test", json!({"got ack": true}))

--- a/socketio/examples/readme.rs
+++ b/socketio/examples/readme.rs
@@ -10,6 +10,7 @@ fn main() {
         match payload {
             Payload::String(str) => println!("Received: {}", str),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+            Payload::Number(num) => println!("Received: {}", num),
         }
         socket
             .emit("test", json!({"got ack": true}))

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -63,6 +63,7 @@ impl ClientBuilder {
     ///            match payload {
     ///                Payload::String(str) => println!("Received: {}", str),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                Payload::Number(num) => println!("Received number: {}", num),
     ///            }
     /// };
     ///
@@ -139,6 +140,7 @@ impl ClientBuilder {
     ///            match payload {
     ///                Payload::String(str) => println!("Received: {}", str),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                Payload::Number(num) => println!("Received number: {}", num),
     ///            }
     ///     })
     ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -61,8 +61,10 @@ impl ClientBuilder {
     ///
     /// let callback = |payload: Payload, socket: RawClient| {
     ///            match payload {
-    ///                Payload::String(str) => println!("Received: {}", str),
+    ///                Payload::Json(data) => println!("Received: {:?}", data),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                Payload::Multi(vec_data) => println!("Received multi: {:?}", vec_data),
+    ///                _ => {}
     ///            }
     /// };
     ///
@@ -137,8 +139,10 @@ impl ClientBuilder {
     ///     .namespace("/admin")
     ///     .on("test", |payload: Payload, _| {
     ///            match payload {
-    ///                Payload::String(str) => println!("Received: {}", str),
+    ///                Payload::Json(data) => println!("Received: {:?}", data),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                Payload::Multi(vec_data) => println!("Received multi: {:?}", vec_data),
+    ///                _ => {}
     ///            }
     ///     })
     ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))
@@ -166,8 +170,8 @@ impl ClientBuilder {
     /// let client = ClientBuilder::new("http://localhost:4200/")
     ///     .namespace("/admin")
     ///     .on_any(|event, payload, _client| {
-    ///         if let Payload::String(str) = payload {
-    ///           println!("{} {}", String::from(event), str);
+    ///         if let Payload::Json(data) = payload {
+    ///           println!("{} {}", String::from(event), data);
     ///         }
     ///     })
     ///     .connect();

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -63,7 +63,6 @@ impl ClientBuilder {
     ///            match payload {
     ///                Payload::String(str) => println!("Received: {}", str),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
-    ///                Payload::Number(num) => println!("Received number: {}", num),
     ///            }
     /// };
     ///
@@ -140,7 +139,6 @@ impl ClientBuilder {
     ///            match payload {
     ///                Payload::String(str) => println!("Received: {}", str),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
-    ///                Payload::Number(num) => println!("Received number: {}", num),
     ///            }
     ///     })
     ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))

--- a/socketio/src/client/client.rs
+++ b/socketio/src/client/client.rs
@@ -132,7 +132,6 @@ impl Client {
     ///     match message {
     ///         Payload::String(str) => println!("{}", str),
     ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
-    ///         Payload::Number(num) => println!("Received number: {}", num),
     ///    }
     /// };
     ///
@@ -185,7 +184,6 @@ impl Client {
     ///     match message {
     ///         Payload::String(str) => println!("{}", str),
     ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
-    ///         Payload::Number(num) => println!("Received number: {}", num),
     ///    }
     /// };
     ///

--- a/socketio/src/client/client.rs
+++ b/socketio/src/client/client.rs
@@ -70,6 +70,41 @@ impl Client {
         client.emit(event, data)
     }
 
+    /// Sends a message to the server using the underlying `engine.io` protocol.
+    /// This message takes an event, which could either be one of the common
+    /// events like "message" or "error" or a custom event like "foo". But be
+    /// careful, the data string needs to be valid JSON. It's recommended to use
+    /// a library like `serde_json` to serialize the data properly.
+    ///
+    /// # Example
+    /// ```
+    /// use rust_socketio::{ClientBuilder, RawClient, Payload};
+    /// use serde_json::json;
+    ///
+    /// let mut socket = ClientBuilder::new("http://localhost:4200/")
+    ///     .on("test", |payload: Payload, socket: RawClient| {
+    ///         println!("Received: {:#?}", payload);
+    ///         socket.emit("test", json!({"hello": true})).expect("Server unreachable");
+    ///      })
+    ///     .connect()
+    ///     .expect("connection failed");
+    ///
+    /// let payload = vec![json!({"token": 123})];
+    ///
+    /// let result = socket.emit_multi("foo", payload);
+    ///
+    /// assert!(result.is_ok());
+    /// ```
+    pub fn emit_multi<E, D>(&self, event: E, data: Vec<D>) -> Result<()>
+    where
+        E: Into<Event>,
+        D: Into<Payload>,
+    {
+        let client = self.client.read()?;
+        // TODO(#230): like js client, buffer emit, resend after reconnect
+        client.emit_multi(event, data)
+    }
+
     /// Sends a message to the server but `alloc`s an `ack` to check whether the
     /// server responded in a given time span. This message takes an event, which
     /// could either be one of the common events like "message" or "error" or a
@@ -97,6 +132,7 @@ impl Client {
     ///     match message {
     ///         Payload::String(str) => println!("{}", str),
     ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
+    ///         Payload::Number(num) => println!("Received number: {}", num),
     ///    }
     /// };
     ///
@@ -120,6 +156,59 @@ impl Client {
         let client = self.client.read()?;
         // TODO(#230): like js client, buffer emit, resend after reconnect
         client.emit_with_ack(event, data, timeout, callback)
+    }
+
+    /// Sends a message to the server but `alloc`s an `ack` to check whether the
+    /// server responded in a given time span. This message takes an event, which
+    /// could either be one of the common events like "message" or "error" or a
+    /// custom event like "foo", as well as a data parameter. But be careful,
+    /// in case you send a [`Payload::String`], the string needs to be valid JSON.
+    /// It's even recommended to use a library like serde_json to serialize the data properly.
+    /// It also requires a timeout `Duration` in which the client needs to answer.
+    /// If the ack is acked in the correct time span, the specified callback is
+    /// called. The callback consumes a [`Payload`] which represents the data send
+    /// by the server.
+    ///
+    /// # Example
+    /// ```
+    /// use rust_socketio::{ClientBuilder, Payload, RawClient};
+    /// use serde_json::json;
+    /// use std::time::Duration;
+    /// use std::thread::sleep;
+    ///
+    /// let mut socket = ClientBuilder::new("http://localhost:4200/")
+    ///     .on("foo", |payload: Payload, _| println!("Received: {:#?}", payload))
+    ///     .connect()
+    ///     .expect("connection failed");
+    ///
+    /// let ack_callback = |message: Payload, socket: RawClient| {
+    ///     match message {
+    ///         Payload::String(str) => println!("{}", str),
+    ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
+    ///         Payload::Number(num) => println!("Received number: {}", num),
+    ///    }
+    /// };
+    ///
+    /// let payload = vec![json!({"token": 123})];
+    /// socket.emit_multi_with_ack("foo", payload, Duration::from_secs(2), ack_callback).unwrap();
+    ///
+    /// sleep(Duration::from_secs(2));
+    /// ```
+    pub fn emit_multi_with_ack<F, E, D>(
+        &self,
+        event: E,
+        data: Vec<D>,
+        timeout: Duration,
+        callback: F,
+    ) -> Result<()>
+    where
+        F: for<'a> FnMut(Payload, RawClient) + 'static + Sync + Send,
+        E: Into<Event>,
+        D: Into<Payload>,
+    {
+        let client = self.client.read()?;
+        // TODO(#230): like js client, buffer emit, resend after reconnect
+        client.emit_multi_with_ack(event, data, timeout, callback)
     }
 
     /// Disconnects this client from the server by sending a `socket.io` closing

--- a/socketio/src/client/raw_client.rs
+++ b/socketio/src/client/raw_client.rs
@@ -213,7 +213,6 @@ impl RawClient {
     ///     match message {
     ///         Payload::String(str) => println!("{}", str),
     ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
-    ///         Payload::Number(num) => println!("Received number {}", num),
     ///    }
     /// };
     ///
@@ -285,7 +284,6 @@ impl RawClient {
     ///     match message {
     ///         Payload::String(str) => println!("{}", str),
     ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
-    ///         Payload::Number(num) => println!("Received number: {}", num),
     ///    }
     /// };
     ///
@@ -547,7 +545,6 @@ mod test {
             .on("test", |msg, _| match msg {
                 Payload::String(str) => println!("Received string: {}", str),
                 Payload::Binary(bin) => println!("Received binary data: {:#?}", bin),
-                Payload::Number(num) => println!("Received number data: {:#?}", num),
             })
             .connect()?;
 

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -11,8 +11,10 @@
 //! // socket to communicate with the server
 //! let callback = |payload: Payload, socket: RawClient| {
 //!        match payload {
-//!            Payload::String(str) => println!("Received: {}", str),
+//!            Payload::Json(data) => println!("Received: {}", data),
 //!            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+//!            Payload::Multi(vec) => println!("Received multi: {:?}", vec),
+//!            _ => {}
 //!        }
 //!        socket.emit("test", json!({"got ack": true})).expect("Server unreachable")
 //! };

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -13,6 +13,7 @@
 //!        match payload {
 //!            Payload::String(str) => println!("Received: {}", str),
 //!            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+//!            Payload::Number(num) => println!("Received number: {}", num),
 //!        }
 //!        socket.emit("test", json!({"got ack": true})).expect("Server unreachable")
 //! };

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -13,7 +13,6 @@
 //!        match payload {
 //!            Payload::String(str) => println!("Received: {}", str),
 //!            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
-//!            Payload::Number(num) => println!("Received number: {}", num),
 //!        }
 //!        socket.emit("test", json!({"got ack": true})).expect("Server unreachable")
 //! };

--- a/socketio/src/packet.rs
+++ b/socketio/src/packet.rs
@@ -118,24 +118,8 @@ impl From<&Packet> for Bytes {
 
         let mut buffer = BytesMut::new();
         buffer.put(string.as_ref());
-        if packet.attachments.as_ref().is_some() {
-            // check if an event type is present
-            let placeholder = if let Some(event_type) = packet.data.as_ref() {
-                format!(
-                    "[{},{{\"_placeholder\":true,\"num\":{}}}]",
-                    event_type,
-                    packet.attachment_count - 1,
-                )
-            } else {
-                format!(
-                    "[{{\"_placeholder\":true,\"num\":{}}}]",
-                    packet.attachment_count - 1,
-                )
-            };
 
-            // build the buffers
-            buffer.put(placeholder.as_ref());
-        } else if let Some(data) = packet.data.as_ref() {
+        if let Some(data) = packet.data.as_ref() {
             buffer.put(data.as_ref());
         }
 
@@ -540,7 +524,9 @@ mod test {
         let packet = Packet::new(
             PacketId::BinaryEvent,
             "/".to_owned(),
-            Some(String::from("\"hello\"")),
+            Some(String::from(
+                "[\"hello\",{\"_placeholder\":true,\"num\":0}]",
+            )),
             None,
             1,
             Some(vec![Bytes::from_static(&[1, 2, 3])]),
@@ -556,7 +542,9 @@ mod test {
         let packet = Packet::new(
             PacketId::BinaryEvent,
             "/admin".to_owned(),
-            Some(String::from("\"project:delete\"")),
+            Some(String::from(
+                "[\"project:delete\",{\"_placeholder\":true,\"num\":0}]",
+            )),
             Some(456),
             1,
             Some(vec![Bytes::from_static(&[1, 2, 3])]),
@@ -572,7 +560,7 @@ mod test {
         let packet = Packet::new(
             PacketId::BinaryAck,
             "/admin".to_owned(),
-            None,
+            Some(String::from("[{\"_placeholder\":true,\"num\":0}]")),
             Some(456),
             1,
             Some(vec![Bytes::from_static(&[3, 2, 1])]),

--- a/socketio/src/packet.rs
+++ b/socketio/src/packet.rs
@@ -224,7 +224,6 @@ impl TryFrom<&Bytes> for Packet {
 
         packet.data = match json_data {
             Value::Array(vec) if vec.is_empty() => None,
-            // Value::Array(vec) if vec.len() == 1 => vec.get(0).map(|v| v.to_owned()),
             _ => Some(json_data),
         };
 

--- a/socketio/src/payload.rs
+++ b/socketio/src/payload.rs
@@ -9,6 +9,7 @@ use bytes::Bytes;
 pub enum Payload {
     Binary(Bytes),
     String(String),
+    Number(usize),
 }
 
 impl From<&str> for Payload {

--- a/socketio/src/payload.rs
+++ b/socketio/src/payload.rs
@@ -9,7 +9,6 @@ use bytes::Bytes;
 pub enum Payload {
     Binary(Bytes),
     String(String),
-    Number(usize),
 }
 
 impl From<&str> for Payload {
@@ -74,5 +73,11 @@ mod tests {
 
         let sut = Payload::from(Bytes::from_static(&[1, 2, 3]));
         assert_eq!(Payload::Binary(Bytes::from_static(&[1, 2, 3])), sut);
+
+        let sut = Payload::from(json!(5));
+        assert_eq!(Payload::String("5".to_owned()), sut);
+
+        let sut = Payload::from(json!("5"));
+        assert_eq!(Payload::String("\"5\"".to_owned()), sut);
     }
 }

--- a/socketio/src/socket.rs
+++ b/socketio/src/socket.rs
@@ -132,7 +132,6 @@ impl Socket {
     fn encode_payloads(data: &mut String, payloads: Vec<Payload>, attachments: &mut Vec<Bytes>) {
         for (index, payload) in payloads.iter().enumerate() {
             match payload {
-                Payload::Number(num) => *data += &format!("{}", num),
                 Payload::Binary(bin_data) => {
                     *data += "{\"_placeholder\":true,\"num\":";
                     *data += &format!("{}", attachments.len());
@@ -235,6 +234,8 @@ impl Socket {
 
 #[cfg(test)]
 mod test {
+    use serde_json::json;
+
     use super::*;
 
     #[test]
@@ -325,14 +326,15 @@ mod test {
         );
 
         let payloads = vec![
-            crate::Payload::Number(4),
+            crate::Payload::String(json!(3).to_string()),
+            crate::Payload::String(json!("4").to_string()),
             crate::Payload::Binary(Bytes::from_static(&[3, 2, 1])),
         ];
         let packet = Socket::build_packet_for_payloads(payloads, None, "/admin", Some(456), true);
 
         assert_eq!(
             Bytes::from(&packet.unwrap()),
-            "61-/admin,456[4,{\"_placeholder\":true,\"num\":0}]"
+            "61-/admin,456[3,\"4\",{\"_placeholder\":true,\"num\":0}]"
                 .to_string()
                 .into_bytes()
         );


### PR DESCRIPTION
js client can emit multiple parameters in one call. user socketio server `socket.on("foo", async (userId, body, callback)=>{})`  (#246) accept this kind of data which rust-socektio can not emit.
