### PR TITLE
Fix wrong event 'connect' to 'open'

### DIFF
--- a/socketio/src/asynchronous/client/builder.rs
+++ b/socketio/src/asynchronous/client/builder.rs
@@ -91,7 +91,7 @@ impl ClientBuilder {
     }
 
     /// Registers a new callback for a certain [`crate::event::Event`]. The event could either be
-    /// one of the common events like `message`, `error`, `connect`, `close` or a custom
+    /// one of the common events like `message`, `error`, `open`, `close` or a custom
     /// event defined by a string, e.g. `onPayment` or `foo`.
     ///
     /// # Example

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -145,7 +145,7 @@ impl ClientBuilder {
     }
 
     /// Registers a new callback for a certain [`crate::event::Event`]. The event could either be
-    /// one of the common events like `message`, `error`, `connect`, `close` or a custom
+    /// one of the common events like `message`, `error`, `open`, `close` or a custom
     /// event defined by a string, e.g. `onPayment` or `foo`.
     ///
     /// # Example


### PR DESCRIPTION
[current features](https://docs.rs/rust_socketio/latest/rust_socketio/#current-features) at the main page of the documentation lists the supported features correctly, but the [on method's documentation](https://docs.rs/rust_socketio/latest/rust_socketio/struct.SocketBuilder.html#method.on) seems to have a wrong event 'connect' instead of 'open'.

Code to verify:

```rust
        let socket = SocketBuilder::new("http://localhost:3001")
            .on("open", |_,_| println!("Connected!")) // This triggers, "connect" does not trigger
            .connect()
            .expect("Connection failed");
```

It took me a while to figure this out, I hope this helps someone else!