### PR TITLE
fix: only handle Message or MessageBinary packets in async client

### DIFF
--- a/socketio/src/asynchronous/socket.rs
+++ b/socketio/src/asynchronous/socket.rs
@@ -137,10 +137,14 @@ impl Socket {
                 for await received_data in client.clone() {
                     let packet = received_data?;
 
-                    let packet = Self::handle_engineio_packet(packet, client.clone()).await?;
-                    Self::handle_socketio_packet(&packet, is_connected.clone());
+                    if packet.packet_id == EnginePacketId::Message
+                        || packet.packet_id == EnginePacketId::MessageBinary
+                    {
+                        let packet = Self::handle_engineio_packet(packet, client.clone()).await?;
+                        Self::handle_socketio_packet(&packet, is_connected.clone());
 
-                    yield packet;
+                        yield packet;
+                    }
                 }
         })
     }


### PR DESCRIPTION
Similar to the synchronous client, this adds a check to the asynchronous client to only handle packets whose packet_id is either Message or MessageBinary. All other packets like heartbeats are ignored in the SocketIO client stream, as they are handled separately.

Closes #311 