### PR TITLE
perf(socketio): avoid allocs in Bytes: From<&Packet>

### DIFF
--- a/socketio/src/packet.rs
+++ b/socketio/src/packet.rs
@@ -118,20 +118,16 @@ impl From<&Packet> for Bytes {
         }
 
         if packet.attachments.is_some() {
+            let num = packet.attachment_count - 1;
+
             // check if an event type is present
             if let Some(event_type) = packet.data.as_ref() {
                 let _ = write!(
                     buffer,
-                    "[{},{{\"_placeholder\":true,\"num\":{}}}]",
-                    event_type,
-                    packet.attachment_count - 1,
+                    "[{event_type},{{\"_placeholder\":true,\"num\":{num}}}]",
                 );
             } else {
-                let _ = write!(
-                    buffer,
-                    "[{{\"_placeholder\":true,\"num\":{}}}]",
-                    packet.attachment_count - 1,
-                );
+                let _ = write!(buffer, "[{{\"_placeholder\":true,\"num\":{num}}}]");
             }
         } else if let Some(data) = packet.data.as_ref() {
             buffer.push_str(data);

--- a/socketio/src/packet.rs
+++ b/socketio/src/packet.rs
@@ -97,7 +97,7 @@ impl From<&Packet> for Bytes {
     /// stream as it gets handled and send by it's own logic via the socket.
     fn from(packet: &Packet) -> Bytes {
         // first the packet type
-        let mut buffer = String::with_capacity(64);
+        let mut buffer = String::new();
         buffer.push((packet.packet_type as u8 + b'0') as char);
 
         // eventually a number of attachments, followed by '-'


### PR DESCRIPTION
Avoiding intermediate allocations by always writing into the same `String` buffer.