### PR TITLE
perf(socketio): avoid allocs when dealing with events

### DIFF
--- a/socketio/src/asynchronous/client/client.rs
+++ b/socketio/src/asynchronous/client/client.rs
@@ -662,7 +662,7 @@ mod test {
                 let clone_tx = tx.clone();
                 async move {
                     if let Payload::String(str) = payload {
-                        println!("{}: {}", String::from(event.clone()), str);
+                        println!("{event}: {str}");
                     }
                     clone_tx.send(String::from(event)).await.unwrap();
                 }

--- a/socketio/src/asynchronous/socket.rs
+++ b/socketio/src/asynchronous/socket.rs
@@ -117,7 +117,7 @@ impl Socket {
             Payload::String(str_data) => {
                 serde_json::from_str::<IgnoredAny>(&str_data)?;
 
-                let payload = format!("[\"{}\",{}]", String::from(event), str_data);
+                let payload = format!("[\"{event}\",{str_data}]");
 
                 Ok(Packet::new(
                     PacketId::Event,

--- a/socketio/src/client/raw_client.rs
+++ b/socketio/src/client/raw_client.rs
@@ -563,7 +563,7 @@ mod test {
             })
             .on_any(move |event, payload, _client| {
                 if let Payload::String(str) = payload {
-                    println!("{} {}", String::from(event.clone()), str);
+                    println!("{event} {str}");
                 }
                 tx.send(String::from(event)).unwrap();
             })

--- a/socketio/src/event.rs
+++ b/socketio/src/event.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
 /// An `Event` in `socket.io` could either (`Message`, `Error`) or custom.
 #[derive(Debug, PartialEq, PartialOrd, Clone, Eq, Hash)]
 pub enum Event {
@@ -6,6 +8,18 @@ pub enum Event {
     Custom(String),
     Connect,
     Close,
+}
+
+impl Event {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Event::Message => "message",
+            Event::Error => "error",
+            Event::Connect => "connect",
+            Event::Close => "close",
+            Event::Custom(string) => string,
+        }
+    }
 }
 
 impl From<String> for Event {
@@ -35,5 +49,11 @@ impl From<Event> for String {
             Event::Error => Self::from("error"),
             Event::Custom(string) => string,
         }
+    }
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str(self.as_str())
     }
 }

--- a/socketio/src/socket.rs
+++ b/socketio/src/socket.rs
@@ -105,9 +105,9 @@ impl Socket {
             )),
             Payload::String(str_data) => {
                 let payload = if serde_json::from_str::<IgnoredAny>(&str_data).is_ok() {
-                    format!("[\"{}\",{}]", String::from(event), str_data)
+                    format!("[\"{event}\",{str_data}]")
                 } else {
-                    format!("[\"{}\",\"{}\"]", String::from(event), str_data)
+                    format!("[\"{event}\",\"{str_data}\"]")
                 };
 
                 Ok(Packet::new(


### PR DESCRIPTION
This avoids some more allocations by
- formatting events directly instead of using `String: From<Event>`
- creating events directly instead of using `Event: From<&str>`

I also copied the `handle_event` method of the async client for the non-async client.