### PR TITLE
perf(socketio): validate json via IgnoredAny

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "native-tls",
  "rand",
  "rust_engineio",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/socketio/Cargo.toml
+++ b/socketio/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.16.1", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["sink"], optional = true }
 async-stream = { version = "0.3.5", optional = true }
 log = "0.4.17"
+serde = "1.0.163"
 
 [dev-dependencies]
 cargo-tarpaulin = "0.18.5"

--- a/socketio/src/asynchronous/socket.rs
+++ b/socketio/src/asynchronous/socket.rs
@@ -10,6 +10,8 @@ use futures_util::{Stream, StreamExt};
 use rust_engineio::{
     asynchronous::Client as EngineClient, Packet as EnginePacket, PacketId as EnginePacketId,
 };
+use serde::de::IgnoredAny;
+use serde_json::Value;
 use std::{
     fmt::Debug,
     pin::Pin,
@@ -107,13 +109,13 @@ impl Socket {
                     PacketId::BinaryEvent
                 },
                 nsp.to_owned(),
-                Some(serde_json::Value::String(event.into()).to_string()),
+                Some(Value::String(event.into()).to_string()),
                 id,
                 1,
                 Some(vec![bin_data]),
             )),
             Payload::String(str_data) => {
-                serde_json::from_str::<serde_json::Value>(&str_data)?;
+                serde_json::from_str::<IgnoredAny>(&str_data)?;
 
                 let payload = format!("[\"{}\",{}]", String::from(event), str_data);
 

--- a/socketio/src/packet.rs
+++ b/socketio/src/packet.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, Result};
 use bytes::Bytes;
+use serde::de::IgnoredAny;
 
 use std::convert::TryFrom;
 use std::fmt::Write;
@@ -189,7 +190,7 @@ impl TryFrom<&Bytes> for Packet {
         }
 
         // validate json
-        serde_json::from_str::<serde_json::Value>(payload).map_err(Error::InvalidJson)?;
+        serde_json::from_str::<IgnoredAny>(payload).map_err(Error::InvalidJson)?;
 
         match packet.packet_type {
             PacketId::BinaryAck | PacketId::BinaryEvent => {

--- a/socketio/src/socket.rs
+++ b/socketio/src/socket.rs
@@ -2,6 +2,8 @@ use crate::error::{Error, Result};
 use crate::packet::{Packet, PacketId};
 use bytes::Bytes;
 use rust_engineio::{Client as EngineClient, Packet as EnginePacket, PacketId as EnginePacketId};
+use serde::de::IgnoredAny;
+use serde_json::Value;
 use std::convert::TryFrom;
 use std::sync::{atomic::AtomicBool, Arc};
 use std::{fmt::Debug, sync::atomic::Ordering};
@@ -96,13 +98,13 @@ impl Socket {
                     PacketId::BinaryEvent
                 },
                 nsp.to_owned(),
-                Some(serde_json::Value::String(event.into()).to_string()),
+                Some(Value::String(event.into()).to_string()),
                 id,
                 1,
                 Some(vec![bin_data]),
             )),
             Payload::String(str_data) => {
-                let payload = if serde_json::from_str::<serde_json::Value>(&str_data).is_ok() {
+                let payload = if serde_json::from_str::<IgnoredAny>(&str_data).is_ok() {
                     format!("[\"{}\",{}]", String::from(event), str_data)
                 } else {
                     format!("[\"{}\",\"{}\"]", String::from(event), str_data)


### PR DESCRIPTION
Ensuring a valid json format via [`serde::de::IgnoredAny`](https://docs.rs/serde/latest/serde/de/struct.IgnoredAny.html) instead of [`serde_json::Value`](https://docs.rs/serde_json/latest/serde_json/enum.Value.html) performs about 2x faster.

I added `serde` as direct dependency but since it was already used transitively, it's not a new dependency.

Closes #329 

I noticed a small discrepancy between [async](https://github.com/1c3t3a/rust-socketio/blob/b61c0376d08f53577ffdc58a1d355fdff60e68c1/socketio/src/asynchronous/socket.rs#L118-L120) and [non-async](https://github.com/1c3t3a/rust-socketio/blob/b61c0376d08f53577ffdc58a1d355fdff60e68c1/socketio/src/socket.rs#L107-L111) code; I can't judge which one is correct though.