### PR TITLE
Bump tungstenite version to `v0.20.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,12 +116,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
@@ -558,6 +552,12 @@ dependencies = [
  "quote",
  "syn 1.0.107",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "deflate"
@@ -1527,7 +1527,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
- "base64 0.21.2",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1567,7 +1567,7 @@ dependencies = [
  "adler32",
  "async-stream",
  "async-trait",
- "base64 0.21.2",
+ "base64",
  "bytes",
  "criterion",
  "futures-util",
@@ -1591,7 +1591,7 @@ dependencies = [
  "adler32",
  "async-stream",
  "backoff",
- "base64 0.21.2",
+ "base64",
  "bytes",
  "cargo-tarpaulin",
  "futures-util",
@@ -1761,10 +1761,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
+name = "sha1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1973,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -2072,19 +2072,19 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
+ "data-encoding",
  "http",
  "httparse",
  "log",
  "native-tls",
  "rand",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",

--- a/engineio/Cargo.toml
+++ b/engineio/Cargo.toml
@@ -18,8 +18,8 @@ adler32 = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 http = "0.2.9"
-tokio-tungstenite = { version = "0.17.2", features = ["native-tls"] }
-tungstenite = "0.17.3"
+tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
+tungstenite = "0.20.1"
 tokio = "1.16.1"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 async-trait = "0.1.68"

--- a/engineio/src/asynchronous/async_transports/websocket_secure.rs
+++ b/engineio/src/asynchronous/async_transports/websocket_secure.rs
@@ -45,8 +45,15 @@ impl WebsocketSecureTransport {
             req.headers_mut().extend(map);
         }
 
+        // `disable_nagle` Sets the value of the TCP_NODELAY option on this socket.
+        //
+        // If set to `true`, this option disables the Nagle algorithm.
+        // This means that segments are always sent as soon as possible, even if there is only a small amount of data.
+        // When `false`, data is buffered until there is a sufficient amount to send out, thereby avoiding the frequent sending of small packets.
+        //
+        // See the docs: https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html#method.set_nodelay
         let (ws_stream, _) =
-            connect_async_tls_with_config(req, None, false, tls_config.map(Connector::NativeTls)).await?;
+            connect_async_tls_with_config(req, None, /*disable_nagle=*/false, tls_config.map(Connector::NativeTls)).await?;
 
         let (sen, rec) = ws_stream.split();
         let inner = AsyncWebsocketGeneralTransport::new(sen, rec).await;

--- a/engineio/src/asynchronous/async_transports/websocket_secure.rs
+++ b/engineio/src/asynchronous/async_transports/websocket_secure.rs
@@ -46,7 +46,7 @@ impl WebsocketSecureTransport {
         }
 
         let (ws_stream, _) =
-            connect_async_tls_with_config(req, None, tls_config.map(Connector::NativeTls)).await?;
+            connect_async_tls_with_config(req, None, false, tls_config.map(Connector::NativeTls)).await?;
 
         let (sen, rec) = ws_stream.split();
         let inner = AsyncWebsocketGeneralTransport::new(sen, rec).await;

--- a/engineio/src/asynchronous/async_transports/websocket_secure.rs
+++ b/engineio/src/asynchronous/async_transports/websocket_secure.rs
@@ -52,8 +52,13 @@ impl WebsocketSecureTransport {
         // When `false`, data is buffered until there is a sufficient amount to send out, thereby avoiding the frequent sending of small packets.
         //
         // See the docs: https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html#method.set_nodelay
-        let (ws_stream, _) =
-            connect_async_tls_with_config(req, None, /*disable_nagle=*/false, tls_config.map(Connector::NativeTls)).await?;
+        let (ws_stream, _) = connect_async_tls_with_config(
+            req,
+            None,
+            /*disable_nagle=*/ false,
+            tls_config.map(Connector::NativeTls),
+        )
+        .await?;
 
         let (sen, rec) = ws_stream.split();
         let inner = AsyncWebsocketGeneralTransport::new(sen, rec).await;


### PR DESCRIPTION
This PR bumps the `tungstenite` (and `tokio-tungstenite` ) version to `0.20.1` to resolve a vulnerability.