### PR TITLE
feat!: support multiple arguments to the payload

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
 
+# Install socat needed for TCP proxy
+RUN apt update && apt install -y socat
+
 COPY ./ci/cert/ca.crt /usr/local/share/ca-certificates/
 
 RUN update-ca-certificates

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,34 +8,45 @@
     "service": "rust-client",
     "workspaceFolder": "/workspace/rust-socketio",
     "shutdownAction": "stopCompose",
-    // Set *default* container specific settings.json values on container create.
-    "settings": {
-        "lldb.executable": "/usr/bin/lldb",
-        // VS Code don't watch files under ./target
-        "files.watcherExclude": {
-            "**/target/**": true
-        } /*,
-        // If you prefer rust-analzyer to be less noisy consider these settings to your settings.json
-        "editor.semanticTokenColorCustomizations": {
-            "rules": {
-                "*.mutable": {
-                    "underline": false
-                }
-            }
-        },
-        "rust-analyzer.inlayHints.parameterHints": false
-        */
+    "customizations": {
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.executable": "/usr/bin/lldb",
+                // VS Code don't watch files under ./target
+                "files.watcherExclude": {
+                    "**/target/**": true
+                },
+                "rust-analyzer.cargo.features": [
+                    "async"
+                ]
+                /*,
+                // If you prefer rust-analzyer to be less noisy consider these settings to your settings.json
+                "editor.semanticTokenColorCustomizations": {
+                    "rules": {
+                        "*.mutable": {
+                            "underline": false
+                        }
+                    }
+                },
+                "rust-analyzer.inlayHints.parameterHints": false
+                */
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "rust-lang.rust-analyzer",
+                "bungcip.better-toml",
+                "vadimcn.vscode-lldb",
+                "eamodio.gitlens",
+                "streetsidesoftware.code-spell-checker"
+            ]
+        }
     },
-    // Add the IDs of extensions you want installed when the container is created.
-    "extensions": [
-        "rust-lang.rust-analyzer",
-        "bungcip.better-toml",
-        "vadimcn.vscode-lldb",
-        "eamodio.gitlens",
-        "streetsidesoftware.code-spell-checker"
-    ],
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // "forwardPorts": [],
-    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-    "remoteUser": "vscode"
+    "remoteUser": "vscode",
+    // Start a TCP proxy from to the testing node-socket-io server so doc tests can pass.
+    "postAttachCommand": {
+        "SocketIOProxy": "socat TCP-LISTEN:4200,fork,reuseaddr TCP:node-socket-io:4200",
+        "EngineIOProxy": "socat TCP-LISTEN:4201,fork,reuseaddr TCP:node-engine-io:4201",
+        "SocketIOAuthProxy": "socat TCP-LISTEN:4204,fork,reuseaddr TCP:node-socket-io-auth:4204"
+    }
 }

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -67,7 +67,7 @@ services:
             - "..:/workspace/rust-socketio"
         environment:
             - "SOCKET_IO_SERVER=http://node-socket-io:4200"
-            - "SOCKET_IO_AUTH_SERVER=http://node-socket-io:4204"
+            - "SOCKET_IO_AUTH_SERVER=http://node-socket-io-auth:4204"
             - "ENGINE_IO_SERVER=http://node-engine-io:4201"
             - "ENGINE_IO_SECURE_SERVER=https://node-engine-io-secure:4202"
             - "ENGINE_IO_SECURE_HOST=node-engine-io-secure"

--- a/ci/socket-io.js
+++ b/ci/socket-io.js
@@ -40,6 +40,9 @@ var callback = client => {
     client.emit('test', 'Hello from the test event!');
     client.emit(Buffer.from([4, 5, 6]));
     client.emit('test', Buffer.from([1, 2, 3]));
+    client.emit('This is the first argument', 'This is the second argument', {
+        argCount: 3
+    });
 };
 io.on('connection', callback);
 io.of('/admin').on('connection', callback);

--- a/socketio/examples/async.rs
+++ b/socketio/examples/async.rs
@@ -14,7 +14,7 @@ async fn main() {
     let callback = |payload: Payload, socket: Client| {
         async move {
             match payload {
-                Payload::Text(values) => println!("Received: {:?}", values),
+                Payload::Text(values) => println!("Received: {:#?}", values),
                 Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
                 // Use Payload::Text instead
                 #[allow(deprecated)]

--- a/socketio/examples/async.rs
+++ b/socketio/examples/async.rs
@@ -14,8 +14,11 @@ async fn main() {
     let callback = |payload: Payload, socket: Client| {
         async move {
             match payload {
-                Payload::String(str) => println!("Received: {}", str),
+                Payload::Text(values) => println!("Received: {:?}", values),
                 Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+                // Use Payload::Text instead
+                #[allow(deprecated)]
+                Payload::String(str) => println!("Received: {}", str),
             }
             socket
                 .emit("test", json!({"got ack": true}))

--- a/socketio/examples/callback.rs
+++ b/socketio/examples/callback.rs
@@ -11,7 +11,7 @@ fn main() {
     // socket to communicate with the server
     let handle_test = |payload: Payload, socket: RawClient| {
         match payload {
-            Payload::Text(text) => println!("Received json: {:?}", text),
+            Payload::Text(text) => println!("Received json: {:#?}", text),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
             #[allow(deprecated)]
             // Use Payload::Text instead

--- a/socketio/examples/callback.rs
+++ b/socketio/examples/callback.rs
@@ -11,8 +11,11 @@ fn main() {
     // socket to communicate with the server
     let handle_test = |payload: Payload, socket: RawClient| {
         match payload {
-            Payload::String(str) => println!("Received string: {}", str),
+            Payload::Text(text) => println!("Received json: {:?}", text),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+            #[allow(deprecated)]
+            // Use Payload::Text instead
+            Payload::String(str) => println!("Received string: {}", str),
         }
         socket
             .emit("test", json!({"got ack": true}))

--- a/socketio/examples/readme.rs
+++ b/socketio/examples/readme.rs
@@ -8,7 +8,9 @@ fn main() {
     // socket to communicate with the server
     let callback = |payload: Payload, socket: RawClient| {
         match payload {
+            #[allow(deprecated)]
             Payload::String(str) => println!("Received: {}", str),
+            Payload::Text(text) => println!("Received json: {:?}", text),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
         }
         socket

--- a/socketio/examples/readme.rs
+++ b/socketio/examples/readme.rs
@@ -10,7 +10,7 @@ fn main() {
         match payload {
             #[allow(deprecated)]
             Payload::String(str) => println!("Received: {}", str),
-            Payload::Text(text) => println!("Received json: {:?}", text),
+            Payload::Text(text) => println!("Received json: {:#?}", text),
             Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
         }
         socket

--- a/socketio/src/asynchronous/client/builder.rs
+++ b/socketio/src/asynchronous/client/builder.rs
@@ -48,8 +48,10 @@ impl ClientBuilder {
     ///     let callback = |payload: Payload, socket: Client| {
     ///         async move {
     ///             match payload {
-    ///                 Payload::String(str) => println!("Received: {}", str),
+    ///                 Payload::Text(values) => println!("Received: {:?}", values),
     ///                 Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                 // This is deprecated, use Payload::Text instead
+    ///                 Payload::String(str) => println!("Received: {}", str),
     ///             }
     ///         }.boxed()
     ///     };
@@ -112,8 +114,10 @@ impl ClientBuilder {
     ///         .on("test", |payload: Payload, _| {
     ///             async move {
     ///                 match payload {
-    ///                        Payload::String(str) => println!("Received: {}", str),
-    ///                       Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                     Payload::Text(values) => println!("Received: {:?}", values),
+    ///                     Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                     // This is deprecated, use Payload::Text instead
+    ///                     Payload::String(str) => println!("Received: {}", str),
     ///                 }
     ///             }
     ///             .boxed()
@@ -146,8 +150,10 @@ impl ClientBuilder {
     ///     let callback = |payload: Payload, _| {
     ///             async move {
     ///                 match payload {
-    ///                        Payload::String(str) => println!("Received: {}", str),
-    ///                       Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                     Payload::Text(values) => println!("Received: {:?}", values),
+    ///                     Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                     // This is deprecated use Payload::Text instead
+    ///                     Payload::String(str) => println!("Received: {}", str),
     ///                 }
     ///             }
     ///             .boxed() // <-- this makes sure we end up with a `BoxFuture<_>`

--- a/socketio/src/asynchronous/client/builder.rs
+++ b/socketio/src/asynchronous/client/builder.rs
@@ -48,7 +48,7 @@ impl ClientBuilder {
     ///     let callback = |payload: Payload, socket: Client| {
     ///         async move {
     ///             match payload {
-    ///                 Payload::Text(values) => println!("Received: {:?}", values),
+    ///                 Payload::Text(values) => println!("Received: {:#?}", values),
     ///                 Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
     ///                 // This is deprecated, use Payload::Text instead
     ///                 Payload::String(str) => println!("Received: {}", str),
@@ -114,7 +114,7 @@ impl ClientBuilder {
     ///         .on("test", |payload: Payload, _| {
     ///             async move {
     ///                 match payload {
-    ///                     Payload::Text(values) => println!("Received: {:?}", values),
+    ///                     Payload::Text(values) => println!("Received: {:#?}", values),
     ///                     Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
     ///                     // This is deprecated, use Payload::Text instead
     ///                     Payload::String(str) => println!("Received: {}", str),
@@ -150,7 +150,7 @@ impl ClientBuilder {
     ///     let callback = |payload: Payload, _| {
     ///             async move {
     ///                 match payload {
-    ///                     Payload::Text(values) => println!("Received: {:?}", values),
+    ///                     Payload::Text(values) => println!("Received: {:#?}", values),
     ///                     Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
     ///                     // This is deprecated use Payload::Text instead
     ///                     Payload::String(str) => println!("Received: {}", str),

--- a/socketio/src/asynchronous/client/client.rs
+++ b/socketio/src/asynchronous/client/client.rs
@@ -189,7 +189,7 @@ impl Client {
     ///     let ack_callback = |message: Payload, socket: Client| {
     ///         async move {
     ///             match message {
-    ///                 Payload::Text(values) => println!("{:?}", values),
+    ///                 Payload::Text(values) => println!("{:#?}", values),
     ///                 Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
     ///                 // This is deprecated use Payload::Text instead
     ///                 Payload::String(str) => println!("{}", str),
@@ -457,7 +457,7 @@ mod test {
             .on("test", |msg, _| {
                 async {
                     match msg {
-                        Payload::Text(values) => println!("Received json: {:?}", values),
+                        Payload::Text(values) => println!("Received json: {:#?}", values),
                         #[allow(deprecated)]
                         Payload::String(str) => println!("Received string: {}", str),
                         Payload::Binary(bin) => println!("Received binary data: {:#?}", bin),
@@ -488,7 +488,7 @@ mod test {
                         println!("Yehaa! My ack got acked?");
                         if let Payload::Text(json) = message {
                             println!("Received json Ack");
-                            println!("Ack data: {:?}", json);
+                            println!("Ack data: {:#?}", json);
                         }
                     }
                     .boxed()
@@ -652,7 +652,7 @@ mod test {
                 let clone_tx = tx.clone();
                 async move {
                     if let Payload::Text(values) = payload {
-                        println!("{event}: {values:?}");
+                        println!("{event}: {values:#?}");
                     }
                     clone_tx.send(String::from(event)).await.unwrap();
                 }
@@ -844,7 +844,7 @@ mod test {
                 println!("Yehaa! My ack got acked?");
                 if let Payload::Text(values) = message {
                     println!("Received json ack");
-                    println!("Ack data: {:?}", values);
+                    println!("Ack data: {:#?}", values);
                 }
             }
             .boxed()

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -62,7 +62,7 @@ impl ClientBuilder {
     ///
     /// let callback = |payload: Payload, socket: RawClient| {
     ///            match payload {
-    ///                Payload::Text(values) => println!("Received: {:?}", values),
+    ///                Payload::Text(values) => println!("Received: {:#?}", values),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
     ///                // This payload type is deprecated, use Payload::Text instead
     ///                Payload::String(str) => println!("Received: {}", str),
@@ -158,7 +158,7 @@ impl ClientBuilder {
     ///     .namespace("/admin")
     ///     .on("test", |payload: Payload, _| {
     ///            match payload {
-    ///                Payload::Text(values) => println!("Received: {:?}", values),
+    ///                Payload::Text(values) => println!("Received: {:#?}", values),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
     ///                // This payload type is deprecated, use Payload::Text instead
     ///                Payload::String(str) => println!("Received: {}", str),

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -62,8 +62,10 @@ impl ClientBuilder {
     ///
     /// let callback = |payload: Payload, socket: RawClient| {
     ///            match payload {
-    ///                Payload::String(str) => println!("Received: {}", str),
+    ///                Payload::Text(values) => println!("Received: {:?}", values),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                // This payload type is deprecated, use Payload::Text instead
+    ///                Payload::String(str) => println!("Received: {}", str),
     ///            }
     /// };
     ///
@@ -156,8 +158,10 @@ impl ClientBuilder {
     ///     .namespace("/admin")
     ///     .on("test", |payload: Payload, _| {
     ///            match payload {
-    ///                Payload::String(str) => println!("Received: {}", str),
+    ///                Payload::Text(values) => println!("Received: {:?}", values),
     ///                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+    ///                // This payload type is deprecated, use Payload::Text instead
+    ///                Payload::String(str) => println!("Received: {}", str),
     ///            }
     ///     })
     ///     .on("error", |err, _| eprintln!("Error: {:#?}", err))

--- a/socketio/src/client/client.rs
+++ b/socketio/src/client/client.rs
@@ -106,8 +106,10 @@ impl Client {
     ///
     /// let ack_callback = |message: Payload, socket: RawClient| {
     ///     match message {
-    ///         Payload::String(str) => println!("{}", str),
+    ///         Payload::Text(values) => println!("{:?}", values),
     ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
+    ///         // This is deprecated, use Payload::Text instead.
+    ///         Payload::String(str) => println!("{}", str),
     ///    }
     /// };
     ///

--- a/socketio/src/client/client.rs
+++ b/socketio/src/client/client.rs
@@ -106,7 +106,7 @@ impl Client {
     ///
     /// let ack_callback = |message: Payload, socket: RawClient| {
     ///     match message {
-    ///         Payload::Text(values) => println!("{:?}", values),
+    ///         Payload::Text(values) => println!("{:#?}", values),
     ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
     ///         // This is deprecated, use Payload::Text instead.
     ///         Payload::String(str) => println!("{}", str),

--- a/socketio/src/client/raw_client.rs
+++ b/socketio/src/client/raw_client.rs
@@ -178,7 +178,7 @@ impl RawClient {
     ///
     /// let ack_callback = |message: Payload, socket: RawClient| {
     ///     match message {
-    ///         Payload::Text(values) => println!("{:?}", values),
+    ///         Payload::Text(values) => println!("{:#?}", values),
     ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
     ///         // This is deprecated, use Payload::Text instead
     ///         Payload::String(str) => println!("{}", str),
@@ -435,7 +435,7 @@ mod test {
             .on("test", |msg, _| match msg {
                 #[allow(deprecated)]
                 Payload::String(str) => println!("Received string: {}", str),
-                Payload::Text(text) => println!("Received json: {:?}", text),
+                Payload::Text(text) => println!("Received json: {:#?}", text),
                 Payload::Binary(bin) => println!("Received binary data: {:#?}", bin),
             })
             .connect()?;
@@ -453,7 +453,7 @@ mod test {
             println!("Yehaa! My ack got acked?");
             if let Payload::Text(values) = message {
                 println!("Received json Ack");
-                println!("Ack data: {:?}", values);
+                println!("Ack data: {:#?}", values);
             }
         };
 
@@ -563,12 +563,12 @@ mod test {
             .auth(json!({ "password": "123" }))
             .on("auth", |payload, _client| {
                 if let Payload::Text(payload) = payload {
-                    println!("{:?}", payload);
+                    println!("{:#?}", payload);
                 }
             })
             .on_any(move |event, payload, _client| {
                 if let Payload::Text(payload) = payload {
-                    println!("{event} {payload:?}");
+                    println!("{event} {payload:#?}");
                 }
                 tx.send(String::from(event)).unwrap();
             })
@@ -760,7 +760,7 @@ mod test {
                     println!("Yehaa! My ack got acked?");
                     if let Payload::Text(values) = message {
                         println!("Received ack");
-                        println!("Ack data: {values:?}");
+                        println!("Ack data: {values:#?}");
                     }
                 }
             )

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -11,7 +11,7 @@
 //! // socket to communicate with the server
 //! let callback = |payload: Payload, socket: RawClient| {
 //!        match payload {
-//!            Payload::Text(values) => println!("Received: {:?}", values),
+//!            Payload::Text(values) => println!("Received: {:#?}", values),
 //!            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
 //!            // This variant is deprecated, use Payload::Text instead
 //!            Payload::String(str) => println!("Received: {}", str),
@@ -109,7 +109,7 @@ async fn main() {
     let callback = |payload: Payload, socket: Client| {
         async move {
             match payload {
-                Payload::Text(values) => println!("Received: {:?}", values),
+                Payload::Text(values) => println!("Received: {:#?}", values),
                 Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
                 // This is deprecated use Payload::Text instead
                 Payload::String(str) => println!("Received: {}", str),

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -11,8 +11,10 @@
 //! // socket to communicate with the server
 //! let callback = |payload: Payload, socket: RawClient| {
 //!        match payload {
-//!            Payload::String(str) => println!("Received: {}", str),
+//!            Payload::Text(values) => println!("Received: {:?}", values),
 //!            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+//!            // This variant is deprecated, use Payload::Text instead
+//!            Payload::String(str) => println!("Received: {}", str),
 //!        }
 //!        socket.emit("test", json!({"got ack": true})).expect("Server unreachable")
 //! };
@@ -73,86 +75,91 @@
 //! handling).
 //! - send JSON data to the server and receive an `ack`.
 //! - send and handle Binary data.
-//!
-//! ## Async version
-//! This library provides an ability for being executed in an asynchronous context using `tokio` as
-//! the execution runtime.
-//! Please note that the current async implementation is in beta, the interface can be object to
-//! drastic changes.
-//! The async `Client` and `ClientBuilder` support a similar interface to the sync version and live
-//! in the [`asynchronous`] module. In order to enable the support, you need to enable the `async`
-//! feature flag:
-//! ```toml
-//! rust_socketio = { version = "0.4.0-alpha.1", features = ["async"] }
-//! ```
-//!
-//! The following code shows the example above in async fashion:
-//!
-//! ``` rust
-//! use futures_util::FutureExt;
-//! use rust_socketio::{
-//!     asynchronous::{Client, ClientBuilder},
-//!     Payload,
-//! };
-//! use serde_json::json;
-//! use std::time::Duration;
-//!
-//! #[tokio::main]
-//! async fn main() {
-//!     // define a callback which is called when a payload is received
-//!     // this callback gets the payload as well as an instance of the
-//!     // socket to communicate with the server
-//!     let callback = |payload: Payload, socket: Client| {
-//!         async move {
-//!             match payload {
-//!                 Payload::String(str) => println!("Received: {}", str),
-//!                 Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
-//!             }
-//!             socket
-//!                 .emit("test", json!({"got ack": true}))
-//!                 .await
-//!                 .expect("Server unreachable");
-//!         }
-//!         .boxed()
-//!     };
-//!
-//!     // get a socket that is connected to the admin namespace
-//!     let socket = ClientBuilder::new("http://localhost:4200/")
-//!         .namespace("/admin")
-//!         .on("test", callback)
-//!         .on("error", |err, _| {
-//!             async move { eprintln!("Error: {:#?}", err) }.boxed()
-//!         })
-//!         .connect()
-//!         .await
-//!         .expect("Connection failed");
-//!
-//!     // emit to the "foo" event
-//!     let json_payload = json!({"token": 123});
-//!     socket
-//!         .emit("foo", json_payload)
-//!         .await
-//!         .expect("Server unreachable");
-//!
-//!     // define a callback, that's executed when the ack got acked
-//!     let ack_callback = |message: Payload, _: Client| {
-//!         async move {
-//!             println!("Yehaa! My ack got acked?");
-//!             println!("Ack data: {:#?}", message);
-//!         }
-//!         .boxed()
-//!     };
-//!
-//!     let json_payload = json!({"myAckData": 123});
-//!     // emit with an ack
-//!     socket
-//!         .emit_with_ack("test", json_payload, Duration::from_secs(2), ack_callback)
-//!         .await
-//!         .expect("Server unreachable");
-//!
-//!     socket.disconnect().await.expect("Disconnect failed");
-//! }
-//! ```
+#![cfg_attr(
+    feature = "async",
+    doc = r#"
+## Async version
+This library provides an ability for being executed in an asynchronous context using `tokio` as
+the execution runtime.
+Please note that the current async implementation is in beta, the interface can be object to
+drastic changes.
+The async `Client` and `ClientBuilder` support a similar interface to the sync version and live
+in the [`asynchronous`] module. In order to enable the support, you need to enable the `async`
+feature flag:
+```toml
+rust_socketio = { version = "0.4.0-alpha.1", features = ["async"] }
+```
+
+The following code shows the example above in async fashion:
+
+``` rust
+use futures_util::FutureExt;
+use rust_socketio::{
+    asynchronous::{Client, ClientBuilder},
+    Payload,
+};
+use serde_json::json;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    // define a callback which is called when a payload is received
+    // this callback gets the payload as well as an instance of the
+    // socket to communicate with the server
+    let callback = |payload: Payload, socket: Client| {
+        async move {
+            match payload {
+                Payload::Text(values) => println!("Received: {:?}", values),
+                Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
+                // This is deprecated use Payload::Text instead
+                Payload::String(str) => println!("Received: {}", str),
+            }
+            socket
+                .emit("test", json!({"got ack": true}))
+                .await
+                .expect("Server unreachable");
+        }
+        .boxed()
+    };
+
+    // get a socket that is connected to the admin namespace
+    let socket = ClientBuilder::new("http://localhost:4200/")
+        .namespace("/admin")
+        .on("test", callback)
+        .on("error", |err, _| {
+            async move { eprintln!("Error: {:#?}", err) }.boxed()
+        })
+        .connect()
+        .await
+        .expect("Connection failed");
+
+    // emit to the "foo" event
+    let json_payload = json!({"token": 123});
+    socket
+        .emit("foo", json_payload)
+        .await
+        .expect("Server unreachable");
+
+    // define a callback, that's executed when the ack got acked
+    let ack_callback = |message: Payload, _: Client| {
+        async move {
+            println!("Yehaa! My ack got acked?");
+            println!("Ack data: {:#?}", message);
+        }
+        .boxed()
+    };
+
+    let json_payload = json!({"myAckData": 123});
+    // emit with an ack
+    socket
+        .emit_with_ack("test", json_payload, Duration::from_secs(2), ack_callback)
+        .await
+        .expect("Server unreachable");
+
+    socket.disconnect().await.expect("Disconnect failed");
+}
+```"#
+)]
 #![allow(clippy::rc_buffer)]
 #![warn(clippy::complexity)]
 #![warn(clippy::style)]

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -87,7 +87,7 @@ The async `Client` and `ClientBuilder` support a similar interface to the sync v
 in the [`asynchronous`] module. In order to enable the support, you need to enable the `async`
 feature flag:
 ```toml
-rust_socketio = { version = "0.4.0-alpha.1", features = ["async"] }
+rust_socketio = { version = "^0.4.1", features = ["async"] }
 ```
 
 The following code shows the example above in async fashion:


### PR DESCRIPTION
Added new payload variant called `Text` to support multiple arguments encoded in JSON. The old Payload::String is deprecated, and will be removed shortly. Use `Payload::from(String)` to mimic old behavior

Built on top of @SalahaldinBilal 's work https://github.com/1c3t3a/rust-socketio/pull/379

Also fixed running doc tests in the devcontainer