### PR TITLE
Let handle_event provide Vec<Value> to self.callback

### DIFF
--- a/socketio/src/asynchronous/client/client.rs
+++ b/socketio/src/asynchronous/client/client.rs
@@ -328,7 +328,7 @@ impl Client {
         };
 
         // a socketio message always comes in one of the following two flavors (both JSON):
-        // 1: `["event", "msg"]`
+        // 1: `["event", "msg", ...]`
         // 2: `["msg"]`
         // in case 2, the message is ment for the default message event, in case 1 the event
         // is specified
@@ -349,6 +349,8 @@ impl Client {
                 (event, msg)
             } else {
                 // case 2
+                // FIXME: `["msg", "msg", ...]` could technically happen I believe?
+                // Case 2 could still possibly return less data than desired
                 (
                     Event::Message,
                     vec![contents


### PR DESCRIPTION
This allows the client to receive multiple messages in one event if a server sends that way, e.g. `42["chat", user_information, chat_message]` is one of many events in my server I'm working with at the moment. Some of this can be chalked up to poor socket design but it's still something socket.io allows.

Unsure if this is the best way to approach this problem! It appears to work in my project fine with little to no issues.