### PR TITLE
feat(socketio): notify client of transport completion

### DIFF
--- a/ci/socket-io.js
+++ b/ci/socket-io.js
@@ -36,6 +36,14 @@ var callback = client => {
             ack(Buffer.from([1, 2, 3]));
         }
     });
+
+    // This event allows the test framework to arbitrarily close the underlying connection
+    client.on('close_transport', data => {
+        console.log(['close_transport', 'Request to close transport received'])
+        // Close underlying websocket connection
+        client.client.conn.close();
+    })
+
     client.emit('Hello from the message event!');
     client.emit('test', 'Hello from the test event!');
     client.emit(Buffer.from([4, 5, 6]));

--- a/socketio/src/client/raw_client.rs
+++ b/socketio/src/client/raw_client.rs
@@ -1,7 +1,7 @@
 use super::callback::Callback;
 use crate::packet::{Packet, PacketId};
 use crate::Error;
-pub(crate) use crate::{event::Event, payload::Payload};
+pub(crate) use crate::{event::CloseReason, event::Event, payload::Payload};
 use rand::{thread_rng, Rng};
 use serde_json::Value;
 
@@ -149,7 +149,7 @@ impl RawClient {
         let _ = self.socket.send(disconnect_packet);
         self.socket.disconnect()?;
 
-        let _ = self.callback(&Event::Close, ""); // trigger on_close
+        let _ = self.callback(&Event::Close, CloseReason::IOClientDisconnect.as_str()); // trigger on_close
         Ok(())
     }
 
@@ -372,7 +372,7 @@ impl RawClient {
                     self.callback(&Event::Connect, "")?;
                 }
                 PacketId::Disconnect => {
-                    self.callback(&Event::Close, "")?;
+                    self.callback(&Event::Close, CloseReason::IOServerDisconnect.as_str())?;
                 }
                 PacketId::ConnectError => {
                     self.callback(

--- a/socketio/src/event.rs
+++ b/socketio/src/event.rs
@@ -57,3 +57,38 @@ impl Display for Event {
         f.write_str(self.as_str())
     }
 }
+
+/// A `CloseReason` is the payload of the [`Event::Close`] and specifies the reason for
+/// why it was fired.
+/// These are aligned with the official Socket.IO disconnect reasons, see
+/// https://socket.io/docs/v4/client-socket-instance/#disconnect
+#[derive(Debug, PartialEq, PartialOrd, Clone, Eq, Hash)]
+pub enum CloseReason {
+    IOServerDisconnect,
+    IOClientDisconnect,
+    TransportClose,
+}
+
+impl CloseReason {
+    pub fn as_str(&self) -> &str {
+        match self {
+            // Inspired by https://github.com/socketio/socket.io/blob/d0fc72042068e7eaef448941add617f05e1ec236/packages/socket.io-client/lib/socket.ts#L865
+            CloseReason::IOServerDisconnect => "io server disconnect",
+            // Inspired by https://github.com/socketio/socket.io/blob/d0fc72042068e7eaef448941add617f05e1ec236/packages/socket.io-client/lib/socket.ts#L911
+            CloseReason::IOClientDisconnect => "io client disconnect",
+            CloseReason::TransportClose => "transport close",
+        }
+    }
+}
+
+impl From<CloseReason> for String {
+    fn from(event: CloseReason) -> Self {
+        Self::from(event.as_str())
+    }
+}
+
+impl Display for CloseReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str(self.as_str())
+    }
+}

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -191,7 +191,7 @@ pub mod asynchronous;
 
 pub use error::Error;
 
-pub use {event::Event, payload::Payload};
+pub use {event::CloseReason, event::Event, payload::Payload};
 
 pub use client::{ClientBuilder, RawClient, TransportType};
 


### PR DESCRIPTION
When the async client connects to the server, it spawns a new thread to handle the arriving messages asynchronously, which is immediately detached with no chance of awaiting its completion.

For long-running programs (e.g. a client program that never really disconnects from the server) this can be problematic, as unexpected stream completions would go unnoticed. This may happen if the underlying tungstenite websocket shuts down ('Received close frame: None') but there are no engineio/socketio close frames. Hence, since the stream terminates, the message handling task stops without a Close or Error event being fired.

Thus, we now fire an additional Event::Close when the stream terminates, to signal the (potentially unexpected) close to the user.

Closes #448 

Once we settle on a final solution, I can also write a test for that.