### PR TITLE
ci: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+      patches:
+        # Group cargo patch updates together to minimize PR management faff
+        applies-to: version-updates
+        update-types:
+        - patch


### PR DESCRIPTION
In theory groups all patch bump dependabot PRs into one to reduce strain of many PRs

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

Brought to my attention by @jdraymon