### PR TITLE
Add ability to handle events that expect an ack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ test-fast: keys
 
 run-test-servers:
 	cd ci && docker build -t test_suite:latest . && cd ..
-	docker run -d -p 4200:4200 -p 4201:4201 -p 4202:4202 -p 4203:4203 -p 4204:4204 -p 4205:4205 -p 4206:4206  --name socketio_test test_suite:latest
+	docker run --rm -d -p 4200:4200 -p 4201:4201 -p 4202:4202 -p 4203:4203 -p 4204:4204 -p 4205:4205 -p 4206:4206  --name socketio_test test_suite:latest
 
 test-all: keys run-test-servers
-	@cargo test --verbose --all-features
+	-cargo test --verbose --all-features
 	docker stop socketio_test
 
 clippy:


### PR DESCRIPTION
This adds three new methods to the API surface

- `[Raw]Client::ack(AckId, D)`
- `ClientBuilder::on_with_ack(Event, callback)`
- `ClientBuilder::on_any_with_ack(Event, callback)`

using these it's possible to receive messages that require ack and acknowledge them

Fixes #461 