### PR TITLE
feat: add features for other tls types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,11 @@ jobs:
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Install cargo-all-features
+        run: cargo install cargo-all-features
+
       - name: Build
-        run: cargo build --verbose --all-features
+        run: cargo build-all-features --verbose
       - name: Linting
         run: cargo clippy --verbose --all-features
       - name: Check formatting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         run: cargo test-all-features --verbose --lib --examples
       
       - name: Run doc tests
-        run: cargo test-all-features --verbose --lib --examples --doc
+        run: cargo test-all-features --verbose --doc
 
       - name: Run integration tests
         run: cargo test --verbose --features "async" --benches --tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,5 +48,14 @@ jobs:
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run testsuite
-        run: cargo test --verbose --features "async"
+      - name: Install cargo-all-features
+        run: cargo install cargo-all-features
+
+      - name: Run unit tests
+        run: cargo test-all-features --verbose --lib --examples
+      
+      - name: Run doc tests
+        run: cargo test-all-features --verbose --lib --examples --doc
+
+      - name: Run integration tests
+        run: cargo test --verbose --features "async" --benches --tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,33 +113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f95446d919226d587817a7d21379e6eb099b97b45110a7f272a444ca5c54070"
-dependencies = [
- "aws-lc-sys",
- "mirai-annotations",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ddc4a5b231dd6958b140ff3151b6412b3f4321fab354f399eec8f14b06df62"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "libc",
- "paste",
-]
-
-[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,29 +143,6 @@ name = "base64"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
-
-[[package]]
-name = "bindgen"
-version = "0.69.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
-dependencies = [
- "bitflags 2.6.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.48",
- "which",
-]
 
 [[package]]
 name = "bitflags"
@@ -319,15 +269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,17 +317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,15 +355,6 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
-
-[[package]]
-name = "cmake"
-version = "0.1.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "codespan-reporting"
@@ -697,12 +618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,12 +713,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -948,12 +857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "gzip-header"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,15 +922,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "http"
@@ -1115,7 +1009,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1290,12 +1184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,16 +1201,6 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1434,12 +1312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,12 +1341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,16 +1368,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1651,12 +1507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,16 +1583,6 @@ name = "ppv-lite86"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
-
-[[package]]
-name = "prettyplease"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
-dependencies = [
- "proc-macro2",
- "syn 2.0.48",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1913,7 +1753,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.4",
+ "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -1937,6 +1777,21 @@ dependencies = [
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -1945,8 +1800,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
- "untrusted",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -1965,7 +1820,8 @@ dependencies = [
  "lazy_static",
  "native-tls",
  "reqwest",
- "rustls 0.22.4",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "thiserror",
@@ -1973,6 +1829,7 @@ dependencies = [
  "tokio-tungstenite",
  "tungstenite",
  "url",
+ "webpki",
 ]
 
 [[package]]
@@ -1991,7 +1848,7 @@ dependencies = [
  "native-tls",
  "rand",
  "rust_engineio",
- "rustls 0.23.13",
+ "rustls",
  "serde",
  "serde_json",
  "serial_test",
@@ -2005,12 +1862,6 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -2055,22 +1906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
-dependencies = [
- "aws-lc-rs",
- "log",
- "once_cell",
+ "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2112,10 +1948,9 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "aws-lc-rs",
- "ring",
+ "ring 0.17.8",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2313,6 +2148,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2527,7 +2368,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -2541,7 +2382,7 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
- "rustls 0.22.4",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -2673,7 +2514,7 @@ dependencies = [
  "log",
  "native-tls",
  "rand",
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror",
@@ -2713,6 +2554,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -2878,24 +2725,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.25",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f95446d919226d587817a7d21379e6eb099b97b45110a7f272a444ca5c54070"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ddc4a5b231dd6958b140ff3151b6412b3f4321fab354f399eec8f14b06df62"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +172,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.48",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,9 +202,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -259,11 +309,22 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -315,6 +376,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +425,15 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -616,6 +697,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,7 +731,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -711,6 +798,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -813,13 +906,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -853,6 +946,12 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gzip-header"
@@ -920,6 +1019,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "http"
@@ -995,6 +1103,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1105,7 +1230,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1121,8 +1246,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi 0.3.1",
- "rustix 0.38.1",
- "windows-sys",
+ "rustix 0.38.25",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1142,9 +1267,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -1165,10 +1290,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.149"
+name = "lazycell"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libc"
+version = "0.2.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libgit2-sys"
@@ -1182,6 +1313,16 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1227,9 +1368,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1293,6 +1434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,9 +1464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "native-tls"
@@ -1349,6 +1502,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1416,7 +1579,7 @@ version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1443,6 +1606,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.2+3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1622,7 @@ checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1474,8 +1647,14 @@ dependencies = [
  "libc",
  "redox_syscall 0.4.1",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1554,6 +1733,16 @@ name = "ppv-lite86"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1713,6 +1902,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -1723,7 +1913,9 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.22.4",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1731,6 +1923,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -1738,7 +1931,23 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1756,6 +1965,7 @@ dependencies = [
  "lazy_static",
  "native-tls",
  "reqwest",
+ "rustls 0.22.4",
  "serde",
  "serde_json",
  "thiserror",
@@ -1776,10 +1986,12 @@ dependencies = [
  "bytes",
  "cargo-tarpaulin",
  "futures-util",
+ "getrandom",
  "log",
  "native-tls",
  "rand",
  "rust_engineio",
+ "rustls 0.23.13",
  "serde",
  "serde_json",
  "serial_test",
@@ -1793,6 +2005,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1814,20 +2032,62 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.1"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc6396159432b5c8490d4e301d8c705f61860b8b6c863bf79942ce5401968f3"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
- "windows-sys",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1842,9 +2102,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "ryu"
@@ -2005,6 +2277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,8 +2311,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2047,6 +2331,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2108,7 +2398,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix 0.37.25",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2207,7 +2497,7 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.5",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2232,6 +2522,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,9 +2541,14 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
+ "rustls 0.22.4",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2367,6 +2673,8 @@ dependencies = [
  "log",
  "native-tls",
  "rand",
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
  "url",
@@ -2405,6 +2713,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2467,12 +2781,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"
@@ -2570,6 +2878,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.25",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,7 +2935,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2615,13 +2953,29 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2631,10 +2985,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2643,10 +3009,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2655,10 +3039,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2667,11 +3063,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/engineio/Cargo.toml
+++ b/engineio/Cargo.toml
@@ -30,6 +30,10 @@ async-stream = "0.3.5"
 thiserror = "1.0"
 native-tls = { version = "^0.2", optional = true }
 rustls = { version = "^0.22", optional = true }
+# rustls-pemfile is only needed for unit tests
+rustls-pemfile = { version = "2", optional = true }
+# webpki is only needed for unit tests
+webpki = { version = "0.21", optional = true }
 url = "2.5.2"
 
 [dev-dependencies]
@@ -61,7 +65,7 @@ rustls-tls-native-roots = ["tokio-tungstenite/rustls-tls-native-roots", "_rustls
 rustls-tls-webpki-roots = ["tokio-tungstenite/rustls-tls-webpki-roots", "_rustls-tls"]
 # These features are for internal use only
 _native-tls = ["dep:native-tls", "reqwest/native-tls"]
-_rustls-tls = ["dep:rustls", "reqwest/rustls-tls"]
+_rustls-tls = ["dep:rustls", "reqwest/rustls-tls", "dep:rustls-pemfile", "dep:webpki"]
 
 # This is an internal feature to allow us to build using cargo-all-features and guaranteing that we always have one TLS implementation
 # Do not use this feature directly

--- a/engineio/Cargo.toml
+++ b/engineio/Cargo.toml
@@ -16,19 +16,20 @@ all-features = true
 [dependencies]
 base64 = "0.22.0"
 bytes = "1"
-reqwest = { version = "0.12.4", features = ["blocking", "native-tls", "stream"] }
+reqwest = { version = "0.12.4", features = ["blocking", "stream"] }
 adler32 = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 http = "1.1.0"
-tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.21.0", features = [] }
 tungstenite = "0.21.0"
 tokio = "1.37.0"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 async-trait = "0.1.81"
 async-stream = "0.3.5"
 thiserror = "1.0"
-native-tls = "0.2.12"
+native-tls = { version = "^0.2", optional = true }
+rustls = { version = "^0.22", optional = true }
 url = "2.5.2"
 
 [dev-dependencies]
@@ -51,6 +52,39 @@ harness = false
 bench = false
 
 [features]
-default = ["async"]
+default = ["async", "native-tls"]
 async-callbacks = []
 async = ["async-callbacks"]
+native-tls = ["tokio-tungstenite/native-tls", "_native-tls"]
+native-tls-vendored = ["tokio-tungstenite/native-tls-vendored", "_native-tls"]
+rustls-tls-native-roots = ["tokio-tungstenite/rustls-tls-native-roots", "_rustls-tls"]
+rustls-tls-webpki-roots = ["tokio-tungstenite/rustls-tls-webpki-roots", "_rustls-tls"]
+# These features are for internal use only
+_native-tls = ["dep:native-tls", "reqwest/native-tls"]
+_rustls-tls = ["dep:rustls", "reqwest/rustls-tls"]
+
+# This is an internal feature to allow us to build using cargo-all-features and guaranteing that we always have one TLS implementation
+# Do not use this feature directly
+_fallback-tls = ["native-tls"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)'] }
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+skip_feature_sets = [
+    # Don't allow both at once
+    ["_native-tls", "_rustls-tls"],
+    # No need to compile with both native-tls options
+    ["native-tls", "native-tls-vendored"],
+    # No need to compile with both rustls options
+    ["rustls-tls-native-roots", "rustls-tls-webpki-roots"],
+    # Don't compile with both native-tls and rustls
+    ["native-tls", "rustls-tls-native-roots"],
+    ["native-tls", "rustls-tls-webpki-roots"],
+    ["native-tls-vendored", "rustls-tls-native-roots"],
+    ["native-tls-vendored", "rustls-tls-webpki-roots"],
+]
+always_include_features = ["_fallback-tls"]
+# Don't use the internal features in the build matrix
+denylist = ["_native-tls", "_rustls-tls"]

--- a/engineio/src/asynchronous/async_socket.rs
+++ b/engineio/src/asynchronous/async_socket.rs
@@ -12,14 +12,14 @@ use bytes::Bytes;
 use futures_util::{stream, Stream, StreamExt};
 use tokio::{runtime::Handle, sync::Mutex, time::Instant};
 
+#[cfg(feature = "async-callbacks")]
+use super::callback::OptionalCallback;
 use crate::{
     asynchronous::transport::AsyncTransportType,
     error::Result,
     packet::{HandshakePacket, Payload},
     Error, Packet, PacketId,
 };
-#[cfg(feature = "async-callbacks")]
-use super::callback::OptionalCallback;
 
 #[derive(Clone)]
 pub struct Socket {
@@ -48,16 +48,11 @@ impl Socket {
     pub(crate) fn new(
         transport: AsyncTransportType,
         handshake: HandshakePacket,
-        #[cfg(feature = "async-callbacks")]
-        on_close: OptionalCallback<()>,
-        #[cfg(feature = "async-callbacks")]
-        on_data: OptionalCallback<Bytes>,
-        #[cfg(feature = "async-callbacks")]
-        on_error: OptionalCallback<String>,
-        #[cfg(feature = "async-callbacks")]
-        on_open: OptionalCallback<()>,
-        #[cfg(feature = "async-callbacks")]
-        on_packet: OptionalCallback<Packet>,
+        #[cfg(feature = "async-callbacks")] on_close: OptionalCallback<()>,
+        #[cfg(feature = "async-callbacks")] on_data: OptionalCallback<Bytes>,
+        #[cfg(feature = "async-callbacks")] on_error: OptionalCallback<String>,
+        #[cfg(feature = "async-callbacks")] on_open: OptionalCallback<()>,
+        #[cfg(feature = "async-callbacks")] on_packet: OptionalCallback<Packet>,
     ) -> Self {
         let max_ping_timeout = handshake.ping_interval + handshake.ping_timeout;
 
@@ -324,7 +319,7 @@ impl Debug for Socket {
             .field("on_error", &self.on_error)
             .field("on_open", &self.on_open)
             .field("on_packet", &self.on_packet);
-        
+
         debug.finish()
     }
 }

--- a/engineio/src/asynchronous/async_socket.rs
+++ b/engineio/src/asynchronous/async_socket.rs
@@ -13,48 +13,56 @@ use futures_util::{stream, Stream, StreamExt};
 use tokio::{runtime::Handle, sync::Mutex, time::Instant};
 
 use crate::{
-    asynchronous::{callback::OptionalCallback, transport::AsyncTransportType},
+    asynchronous::transport::AsyncTransportType,
     error::Result,
     packet::{HandshakePacket, Payload},
     Error, Packet, PacketId,
 };
+#[cfg(feature = "async-callbacks")]
+use super::callback::OptionalCallback;
 
 #[derive(Clone)]
 pub struct Socket {
     handle: Handle,
     transport: Arc<Mutex<AsyncTransportType>>,
     transport_raw: AsyncTransportType,
-    on_close: OptionalCallback<()>,
-    on_data: OptionalCallback<Bytes>,
-    on_error: OptionalCallback<String>,
-    on_open: OptionalCallback<()>,
-    on_packet: OptionalCallback<Packet>,
     connected: Arc<AtomicBool>,
     last_ping: Arc<Mutex<Instant>>,
     last_pong: Arc<Mutex<Instant>>,
     connection_data: Arc<HandshakePacket>,
     max_ping_timeout: u64,
+    // Bellow are the fields that are only used when the async-callbacks feature is enabled.
+    #[cfg(feature = "async-callbacks")]
+    on_close: OptionalCallback<()>,
+    #[cfg(feature = "async-callbacks")]
+    on_data: OptionalCallback<Bytes>,
+    #[cfg(feature = "async-callbacks")]
+    on_error: OptionalCallback<String>,
+    #[cfg(feature = "async-callbacks")]
+    on_open: OptionalCallback<()>,
+    #[cfg(feature = "async-callbacks")]
+    on_packet: OptionalCallback<Packet>,
 }
 
 impl Socket {
     pub(crate) fn new(
         transport: AsyncTransportType,
         handshake: HandshakePacket,
+        #[cfg(feature = "async-callbacks")]
         on_close: OptionalCallback<()>,
+        #[cfg(feature = "async-callbacks")]
         on_data: OptionalCallback<Bytes>,
+        #[cfg(feature = "async-callbacks")]
         on_error: OptionalCallback<String>,
+        #[cfg(feature = "async-callbacks")]
         on_open: OptionalCallback<()>,
+        #[cfg(feature = "async-callbacks")]
         on_packet: OptionalCallback<Packet>,
     ) -> Self {
         let max_ping_timeout = handshake.ping_interval + handshake.ping_timeout;
 
         Socket {
             handle: Handle::current(),
-            on_close,
-            on_data,
-            on_error,
-            on_open,
-            on_packet,
             transport: Arc::new(Mutex::new(transport.clone())),
             transport_raw: transport,
             connected: Arc::new(AtomicBool::default()),
@@ -62,6 +70,16 @@ impl Socket {
             last_pong: Arc::new(Mutex::new(Instant::now())),
             connection_data: Arc::new(handshake),
             max_ping_timeout,
+            #[cfg(feature = "async-callbacks")]
+            on_close,
+            #[cfg(feature = "async-callbacks")]
+            on_data,
+            #[cfg(feature = "async-callbacks")]
+            on_error,
+            #[cfg(feature = "async-callbacks")]
+            on_open,
+            #[cfg(feature = "async-callbacks")]
+            on_packet,
         }
     }
 
@@ -71,6 +89,7 @@ impl Socket {
         // SAFETY: Has valid handshake due to type
         self.connected.store(true, Ordering::Release);
 
+        #[cfg(feature = "async-callbacks")]
         if let Some(on_open) = self.on_open.as_ref() {
             let on_open = on_open.clone();
             self.handle.spawn(async move { on_open(()).await });
@@ -85,18 +104,22 @@ impl Socket {
         Ok(())
     }
 
-    /// A helper method that distributes
+    /// A helper method that distributes the incoming packets to the appropriate callbacks.
     pub(super) async fn handle_incoming_packet(&self, packet: Packet) -> Result<()> {
         // check for the appropriate action or callback
+        #[cfg(feature = "async-callbacks")]
         self.handle_packet(packet.clone());
         match packet.packet_id {
             PacketId::MessageBinary => {
+                #[cfg(feature = "async-callbacks")]
                 self.handle_data(packet.data.clone());
             }
             PacketId::Message => {
+                #[cfg(feature = "async-callbacks")]
                 self.handle_data(packet.data.clone());
             }
             PacketId::Close => {
+                #[cfg(feature = "async-callbacks")]
                 self.handle_close();
             }
             PacketId::Upgrade => {
@@ -144,6 +167,7 @@ impl Socket {
     }
 
     pub async fn disconnect(&self) -> Result<()> {
+        #[cfg(feature = "async-callbacks")]
         if let Some(on_close) = self.on_close.as_ref() {
             let on_close = on_close.clone();
             self.handle.spawn(async move { on_close(()).await });
@@ -188,12 +212,16 @@ impl Socket {
 
     /// Calls the error callback with a given message.
     #[inline]
+    #[cfg(feature = "async-callbacks")]
     fn call_error_callback(&self, text: String) {
         if let Some(on_error) = self.on_error.as_ref() {
             let on_error = on_error.clone();
             self.handle.spawn(async move { on_error(text).await });
         }
     }
+
+    #[cfg(not(feature = "async-callbacks"))]
+    fn call_error_callback(&self, _text: String) {}
 
     // Check if the underlying transport client is connected.
     pub(crate) fn is_connected(&self) -> bool {
@@ -221,6 +249,7 @@ impl Socket {
         }
     }
 
+    #[cfg(feature = "async-callbacks")]
     pub(crate) fn handle_packet(&self, packet: Packet) {
         if let Some(on_packet) = self.on_packet.as_ref() {
             let on_packet = on_packet.clone();
@@ -228,6 +257,7 @@ impl Socket {
         }
     }
 
+    #[cfg(feature = "async-callbacks")]
     pub(crate) fn handle_data(&self, data: Bytes) {
         if let Some(on_data) = self.on_data.as_ref() {
             let on_data = on_data.clone();
@@ -235,6 +265,7 @@ impl Socket {
         }
     }
 
+    #[cfg(feature = "async-callbacks")]
     pub(crate) fn handle_close(&self) {
         if let Some(on_close) = self.on_close.as_ref() {
             let on_close = on_close.clone();
@@ -278,17 +309,22 @@ impl Socket {
 #[cfg_attr(tarpaulin, ignore)]
 impl Debug for Socket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Socket")
+        let mut debug = f.debug_struct("Socket");
+        let debug = debug
             .field("transport", &self.transport)
+            .field("connected", &self.connected)
+            .field("last_ping", &self.last_ping)
+            .field("last_pong", &self.last_pong)
+            .field("connection_data", &self.connection_data);
+
+        #[cfg(feature = "async-callbacks")]
+        debug
             .field("on_close", &self.on_close)
             .field("on_data", &self.on_data)
             .field("on_error", &self.on_error)
             .field("on_open", &self.on_open)
-            .field("on_packet", &self.on_packet)
-            .field("connected", &self.connected)
-            .field("last_ping", &self.last_ping)
-            .field("last_pong", &self.last_pong)
-            .field("connection_data", &self.connection_data)
-            .finish()
+            .field("on_packet", &self.on_packet);
+        
+        debug.finish()
     }
 }

--- a/engineio/src/asynchronous/async_transports/polling.rs
+++ b/engineio/src/asynchronous/async_transports/polling.rs
@@ -13,8 +13,8 @@ use tokio::sync::RwLock;
 use url::Url;
 
 use crate::asynchronous::generator::StreamGenerator;
-use crate::{asynchronous::transport::AsyncTransport, error::Result, Error};
 use crate::TlsConfig;
+use crate::{asynchronous::transport::AsyncTransport, error::Result, Error};
 
 /// An asynchronous polling type. Makes use of the nonblocking reqwest types and
 /// methods.

--- a/engineio/src/asynchronous/async_transports/polling.rs
+++ b/engineio/src/asynchronous/async_transports/polling.rs
@@ -5,7 +5,6 @@ use base64::{engine::general_purpose, Engine as _};
 use bytes::{BufMut, Bytes, BytesMut};
 use futures_util::{Stream, StreamExt};
 use http::HeaderMap;
-use native_tls::TlsConnector;
 use reqwest::{Client, ClientBuilder, Response};
 use std::fmt::Debug;
 use std::time::SystemTime;
@@ -15,6 +14,7 @@ use url::Url;
 
 use crate::asynchronous::generator::StreamGenerator;
 use crate::{asynchronous::transport::AsyncTransport, error::Result, Error};
+use crate::TlsConfig;
 
 /// An asynchronous polling type. Makes use of the nonblocking reqwest types and
 /// methods.
@@ -28,7 +28,7 @@ pub struct PollingTransport {
 impl PollingTransport {
     pub fn new(
         base_url: Url,
-        tls_config: Option<TlsConnector>,
+        tls_config: Option<TlsConfig>,
         opening_headers: Option<HeaderMap>,
     ) -> Self {
         let client = match (tls_config, opening_headers) {

--- a/engineio/src/asynchronous/async_transports/websocket_secure.rs
+++ b/engineio/src/asynchronous/async_transports/websocket_secure.rs
@@ -61,7 +61,7 @@ impl WebsocketSecureTransport {
             #[cfg(feature = "_rustls-tls")]
             tls_config.map(Arc::new).map(Connector::Rustls),
             #[cfg(not(any(feature = "_native-tls", feature = "_rustls-tls")))]
-            None,
+            compile_error!("Either feature `_native-tls` or `_rustls-tls` must be enabled"),
         )
         .await?;
 

--- a/engineio/src/asynchronous/client/async_client.rs
+++ b/engineio/src/asynchronous/client/async_client.rs
@@ -92,10 +92,10 @@ impl Debug for Client {
 mod test {
 
     use super::*;
+    use crate::TlsConfig;
     use crate::{asynchronous::ClientBuilder, header::HeaderMap, packet::PacketId, Error};
     use bytes::Bytes;
     use futures_util::StreamExt;
-    use crate::TlsConfig;
     use url::Url;
 
     /// The purpose of this test is to check whether the Client is properly cloneable or not.

--- a/engineio/src/asynchronous/client/async_client.rs
+++ b/engineio/src/asynchronous/client/async_client.rs
@@ -95,7 +95,7 @@ mod test {
     use crate::{asynchronous::ClientBuilder, header::HeaderMap, packet::PacketId, Error};
     use bytes::Bytes;
     use futures_util::StreamExt;
-    use native_tls::TlsConnector;
+    use crate::TlsConfig;
     use url::Url;
 
     /// The purpose of this test is to check whether the Client is properly cloneable or not.
@@ -384,7 +384,7 @@ mod test {
 
         let _ = builder(url.clone())
             .tls_config(
-                TlsConnector::builder()
+                TlsConfig::builder()
                     .danger_accept_invalid_certs(true)
                     .build()
                     .unwrap(),

--- a/engineio/src/asynchronous/client/builder.rs
+++ b/engineio/src/asynchronous/client/builder.rs
@@ -8,8 +8,7 @@ use crate::{
     error::Result,
     header::HeaderMap,
     packet::HandshakePacket,
-    Error, Packet, ENGINE_IO_VERSION,
-    TlsConfig,
+    Error, Packet, TlsConfig, ENGINE_IO_VERSION,
 };
 use bytes::Bytes;
 use futures_util::{future::BoxFuture, StreamExt};

--- a/engineio/src/asynchronous/client/builder.rs
+++ b/engineio/src/asynchronous/client/builder.rs
@@ -9,10 +9,10 @@ use crate::{
     header::HeaderMap,
     packet::HandshakePacket,
     Error, Packet, ENGINE_IO_VERSION,
+    TlsConfig,
 };
 use bytes::Bytes;
 use futures_util::{future::BoxFuture, StreamExt};
-use native_tls::TlsConnector;
 use url::Url;
 
 use super::Client;
@@ -20,7 +20,7 @@ use super::Client;
 #[derive(Clone, Debug)]
 pub struct ClientBuilder {
     url: Url,
-    tls_config: Option<TlsConnector>,
+    tls_config: Option<TlsConfig>,
     headers: Option<HeaderMap>,
     handshake: Option<HandshakePacket>,
     on_error: OptionalCallback<String>,
@@ -54,7 +54,7 @@ impl ClientBuilder {
     }
 
     /// Specify transport's tls config
-    pub fn tls_config(mut self, tls_config: TlsConnector) -> Self {
+    pub fn tls_config(mut self, tls_config: TlsConfig) -> Self {
         self.tls_config = Some(tls_config);
         self
     }

--- a/engineio/src/asynchronous/transport.rs
+++ b/engineio/src/asynchronous/transport.rs
@@ -59,7 +59,6 @@ impl From<WebsocketSecureTransport> for AsyncTransportType {
     }
 }
 
-#[cfg(feature = "async")]
 impl AsyncTransportType {
     pub fn as_transport(&self) -> &(dyn AsyncTransport + Send) {
         match self {

--- a/engineio/src/client/client.rs
+++ b/engineio/src/client/client.rs
@@ -376,7 +376,7 @@ impl<'a> Iterator for Iter<'a> {
 #[cfg(test)]
 mod test {
 
-    use crate::packet::PacketId;
+    use crate::{packet::PacketId, test::tls_connector};
 
     use super::*;
 
@@ -649,10 +649,7 @@ mod test {
 
         let _ = builder(url.clone())
             .tls_config(
-                TlsConfig::builder()
-                    .danger_accept_invalid_certs(true)
-                    .build()
-                    .unwrap(),
+                tls_connector()?
             )
             .build()?;
         let _ = builder(url).headers(headers).build()?;

--- a/engineio/src/client/client.rs
+++ b/engineio/src/client/client.rs
@@ -7,9 +7,8 @@ use crate::error::{Error, Result};
 use crate::header::HeaderMap;
 use crate::packet::{HandshakePacket, Packet, PacketId};
 use crate::transports::{PollingTransport, WebsocketSecureTransport, WebsocketTransport};
-use crate::ENGINE_IO_VERSION;
+use crate::{ENGINE_IO_VERSION, TlsConfig};
 use bytes::Bytes;
-use native_tls::TlsConnector;
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::fmt::Debug;
@@ -30,7 +29,7 @@ pub struct Client {
 #[derive(Clone, Debug)]
 pub struct ClientBuilder {
     url: Url,
-    tls_config: Option<TlsConnector>,
+    tls_config: Option<TlsConfig>,
     headers: Option<HeaderMap>,
     handshake: Option<HandshakePacket>,
     on_error: OptionalCallback<String>,
@@ -64,7 +63,7 @@ impl ClientBuilder {
     }
 
     /// Specify transport's tls config
-    pub fn tls_config(mut self, tls_config: TlsConnector) -> Self {
+    pub fn tls_config(mut self, tls_config: TlsConfig) -> Self {
         self.tls_config = Some(tls_config);
         self
     }
@@ -650,7 +649,7 @@ mod test {
 
         let _ = builder(url.clone())
             .tls_config(
-                TlsConnector::builder()
+                TlsConfig::builder()
                     .danger_accept_invalid_certs(true)
                     .build()
                     .unwrap(),

--- a/engineio/src/client/client.rs
+++ b/engineio/src/client/client.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, Result};
 use crate::header::HeaderMap;
 use crate::packet::{HandshakePacket, Packet, PacketId};
 use crate::transports::{PollingTransport, WebsocketSecureTransport, WebsocketTransport};
-use crate::{ENGINE_IO_VERSION, TlsConfig};
+use crate::{TlsConfig, ENGINE_IO_VERSION};
 use bytes::Bytes;
 use std::convert::TryFrom;
 use std::convert::TryInto;

--- a/engineio/src/lib.rs
+++ b/engineio/src/lib.rs
@@ -99,6 +99,22 @@ pub use client::{Client, ClientBuilder};
 pub use error::Error;
 pub use packet::{Packet, PacketId};
 
+// Re-export TLS configurations to make sockio integration easier
+#[cfg(all(feature = "_native-tls", not(feature = "_rustls-tls")))]
+#[doc(hidden)]
+pub use native_tls::TlsConnector as TlsConfig;
+#[doc(hidden)]
+#[cfg(feature = "_rustls-tls")]
+pub use rustls::ClientConfig as TlsConfig;
+
+// Both native-tls and rustls is not supported at the same time
+#[cfg(not(feature = "_fallback-tls"))]
+#[cfg(all(feature = "_native-tls", feature = "_rustls-tls"))]
+compile_error!("Both native-tls and rustls features are enabled. Please enable only one of them.");
+
+#[cfg(not(any(feature = "_native-tls", feature = "_rustls-tls")))]
+compile_error!("No TLS feature is enabled. Please enable either native-tls or rustls.");
+
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;

--- a/engineio/src/transports/polling.rs
+++ b/engineio/src/transports/polling.rs
@@ -1,8 +1,8 @@
 use crate::error::{Error, Result};
 use crate::transport::Transport;
+use crate::TlsConfig;
 use base64::{engine::general_purpose, Engine as _};
 use bytes::{BufMut, Bytes, BytesMut};
-use native_tls::TlsConnector;
 use reqwest::{
     blocking::{Client, ClientBuilder},
     header::HeaderMap,
@@ -21,7 +21,7 @@ impl PollingTransport {
     /// Creates an instance of `PollingTransport`.
     pub fn new(
         base_url: Url,
-        tls_config: Option<TlsConnector>,
+        tls_config: Option<TlsConfig>,
         opening_headers: Option<HeaderMap>,
     ) -> Self {
         let client = match (tls_config, opening_headers) {

--- a/engineio/src/transports/websocket_secure.rs
+++ b/engineio/src/transports/websocket_secure.rs
@@ -5,8 +5,7 @@ use crate::{
     },
     error::Result,
     transport::Transport,
-    Error,
-    TlsConfig,
+    Error, TlsConfig,
 };
 use bytes::Bytes;
 use http::HeaderMap;

--- a/engineio/src/transports/websocket_secure.rs
+++ b/engineio/src/transports/websocket_secure.rs
@@ -6,10 +6,10 @@ use crate::{
     error::Result,
     transport::Transport,
     Error,
+    TlsConfig,
 };
 use bytes::Bytes;
 use http::HeaderMap;
-use native_tls::TlsConnector;
 use std::{sync::Arc, time::Duration};
 use tokio::runtime::Runtime;
 use url::Url;
@@ -24,7 +24,7 @@ impl WebsocketSecureTransport {
     /// Creates an instance of `WebsocketSecureTransport`.
     pub fn new(
         base_url: Url,
-        tls_config: Option<TlsConnector>,
+        tls_config: Option<TlsConfig>,
         headers: Option<HeaderMap>,
     ) -> Result<Self> {
         let runtime = tokio::runtime::Builder::new_current_thread()

--- a/socketio/Cargo.toml
+++ b/socketio/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 all-features = true
 
 [dependencies]
-rust_engineio = { version = "0.6.0", path = "../engineio" }
+rust_engineio = { version = "0.6.0", path = "../engineio", default-features = false}
 base64 = "0.22.0"
 bytes = "1"
 backoff = "0.4"
@@ -22,13 +22,15 @@ rand = "0.8.5"
 adler32 = "1.2.0"
 serde_json = "1.0"
 thiserror = "1.0"
-native-tls = "0.2.12"
 url = "2.5.2"
 tokio = { version = "1.37.0", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["sink"], optional = true }
 async-stream = { version = "0.3.5", optional = true }
 log = "0.4.22"
 serde = "1.0.209"
+native-tls = { version = "0.2", optional = true }
+rustls = { version = "0.23", optional = true }
+getrandom = "0.2.10"
 
 [dev-dependencies]
 cargo-tarpaulin = "0.18.5"
@@ -40,11 +42,43 @@ version = "1.37.0"
 features = ["macros", "rt-multi-thread"]
 
 [features]
-default = []
+default = ["native-tls"]
 async-callbacks = ["rust_engineio/async-callbacks"]
 async = ["async-callbacks", "rust_engineio/async", "tokio", "futures-util", "async-stream"]
+native-tls = ["rust_engineio/native-tls", "_native-tls"]
+native-tls-vendored = ["rust_engineio/native-tls-vendored", "_native-tls"]
+rustls-tls-native-roots = ["rust_engineio/rustls-tls-native-roots", "_rustls-tls"]
+rustls-tls-webpki-roots = ["rust_engineio/rustls-tls-webpki-roots", "_rustls-tls"]
+_native-tls = ["dep:native-tls"]
+_rustls-tls = ["dep:rustls"]
+
+# This is an internal feature to allow us to build using cargo-all-features and guaranteing that we always have one TLS implementation
+# Do not use this feature directly
+_fallback-tls = ["native-tls", "rust_engineio/_fallback-tls"]
 
 [[example]]
 name = "async"
 path = "examples/async.rs"
-required-features = ["async"]
+required-features = ["async", "native-tls"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)'] }
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true
+skip_feature_sets = [
+    # Don't allow both at once
+    ["_native-tls", "_rustls-tls"],
+    # No need to compile with both native-tls options
+    ["native-tls", "native-tls-vendored"],
+    # No need to compile with both rustls options
+    ["rustls-tls-native-roots", "rustls-tls-webpki-roots"],
+    # Don't compile with both native-tls and rustls
+    ["native-tls", "rustls-tls-native-roots"],
+    ["native-tls", "rustls-tls-webpki-roots"],
+    ["native-tls-vendored", "rustls-tls-native-roots"],
+    ["native-tls-vendored", "rustls-tls-webpki-roots"],
+]
+always_include_features = ["_fallback-tls"]
+# Don't use the internal features in the build matrix
+denylist = ["_native-tls", "_rustls-tls"]

--- a/socketio/Cargo.toml
+++ b/socketio/Cargo.toml
@@ -29,7 +29,7 @@ async-stream = { version = "0.3.5", optional = true }
 log = "0.4.22"
 serde = "1.0.209"
 native-tls = { version = "0.2", optional = true }
-rustls = { version = "0.23", optional = true }
+rustls = { version = "0.22", optional = true }
 getrandom = "0.2.10"
 
 [dev-dependencies]
@@ -60,6 +60,11 @@ _fallback-tls = ["native-tls", "rust_engineio/_fallback-tls"]
 name = "async"
 path = "examples/async.rs"
 required-features = ["async", "native-tls"]
+
+[[example]]
+name = "secure"
+path = "examples/secure.rs"
+required-features = ["native-tls"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)'] }

--- a/socketio/src/asynchronous/client/builder.rs
+++ b/socketio/src/asynchronous/client/builder.rs
@@ -3,12 +3,11 @@ use log::trace;
 use rust_engineio::{
     asynchronous::ClientBuilder as EngineIoClientBuilder,
     header::{HeaderMap, HeaderValue},
-    TlsConfig,
 };
 use std::collections::HashMap;
 use url::Url;
 
-use crate::{error::Result, Event, Payload, TransportType};
+use crate::{error::Result, Event, Payload, TransportType, TlsConfig};
 
 use super::{
     callback::{

--- a/socketio/src/asynchronous/client/builder.rs
+++ b/socketio/src/asynchronous/client/builder.rs
@@ -1,9 +1,9 @@
 use futures_util::future::BoxFuture;
 use log::trace;
-use native_tls::TlsConnector;
 use rust_engineio::{
     asynchronous::ClientBuilder as EngineIoClientBuilder,
     header::{HeaderMap, HeaderValue},
+    TlsConfig,
 };
 use std::collections::HashMap;
 use url::Url;
@@ -28,7 +28,7 @@ pub struct ClientBuilder {
     pub(crate) on_any: Option<Callback<DynAsyncAnyCallback>>,
     pub(crate) on_reconnect: Option<Callback<DynAsyncReconnectSettingsCallback>>,
     pub(crate) namespace: String,
-    tls_config: Option<TlsConnector>,
+    tls_config: Option<TlsConfig>,
     opening_headers: Option<HeaderMap>,
     transport_type: TransportType,
     pub(crate) auth: Option<serde_json::Value>,
@@ -285,7 +285,7 @@ impl ClientBuilder {
     ///         .await;
     /// }
     /// ```
-    pub fn tls_config(mut self, tls_config: TlsConnector) -> Self {
+    pub fn tls_config(mut self, tls_config: TlsConfig) -> Self {
         self.tls_config = Some(tls_config);
         self
     }

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -2,9 +2,9 @@ use super::super::{event::Event, payload::Payload};
 use super::callback::Callback;
 use super::client::Client;
 use crate::RawClient;
-use native_tls::TlsConnector;
 use rust_engineio::client::ClientBuilder as EngineIoClientBuilder;
 use rust_engineio::header::{HeaderMap, HeaderValue};
+use rust_engineio::TlsConfig;
 use url::Url;
 
 use crate::client::callback::{SocketAnyCallback, SocketCallback};
@@ -37,7 +37,7 @@ pub struct ClientBuilder {
     on: Arc<Mutex<HashMap<Event, Callback<SocketCallback>>>>,
     on_any: Arc<Mutex<Option<Callback<SocketAnyCallback>>>>,
     namespace: String,
-    tls_config: Option<TlsConnector>,
+    tls_config: Option<TlsConfig>,
     opening_headers: Option<HeaderMap>,
     transport_type: TransportType,
     auth: Option<serde_json::Value>,
@@ -227,7 +227,7 @@ impl ClientBuilder {
     ///     .connect();
     ///
     /// ```
-    pub fn tls_config(mut self, tls_config: TlsConnector) -> Self {
+    pub fn tls_config(mut self, tls_config: TlsConfig) -> Self {
         self.tls_config = Some(tls_config);
         self
     }

--- a/socketio/src/client/builder.rs
+++ b/socketio/src/client/builder.rs
@@ -1,10 +1,9 @@
 use super::super::{event::Event, payload::Payload};
 use super::callback::Callback;
 use super::client::Client;
-use crate::RawClient;
+use crate::{RawClient, TlsConfig};
 use rust_engineio::client::ClientBuilder as EngineIoClientBuilder;
 use rust_engineio::header::{HeaderMap, HeaderValue};
-use rust_engineio::TlsConfig;
 use url::Url;
 
 use crate::client::callback::{SocketAnyCallback, SocketCallback};

--- a/socketio/src/client/raw_client.rs
+++ b/socketio/src/client/raw_client.rs
@@ -418,9 +418,23 @@ mod test {
     use super::*;
     use crate::{client::TransportType, payload::Payload, ClientBuilder};
     use bytes::Bytes;
-    use native_tls::TlsConnector;
     use serde_json::json;
     use std::time::Duration;
+
+    #[cfg(feature = "_native-tls")]
+    fn tls_config() -> native_tls::TlsConnector {
+        native_tls::TlsConnector::builder()
+            .use_sni(true)
+            .build()
+            .expect("Found illegal configuration")
+    }
+
+    #[cfg(feature = "_rustls-tls")]
+    fn tls_config() -> rustls::ClientConfig {
+        rustls::ClientConfig::builder()
+            .with_root_certificates(rustls::RootCertStore::empty())
+            .with_no_client_auth()
+    }
 
     #[test]
     fn socket_io_integration() -> Result<()> {
@@ -474,14 +488,9 @@ mod test {
         // test socket build logic
         let socket_builder = ClientBuilder::new(url);
 
-        let tls_connector = TlsConnector::builder()
-            .use_sni(true)
-            .build()
-            .expect("Found illegal configuration");
-
         let socket = socket_builder
             .namespace("/admin")
-            .tls_config(tls_connector)
+            .tls_config(tls_config())
             .opening_header("accept-encoding", "application/json")
             .on("test", |str, _| println!("Received: {:#?}", str))
             .on("message", |payload, _| println!("{:#?}", payload))
@@ -515,14 +524,9 @@ mod test {
         // test socket build logic
         let socket_builder = ClientBuilder::new(url);
 
-        let tls_connector = TlsConnector::builder()
-            .use_sni(true)
-            .build()
-            .expect("Found illegal configuration");
-
         let socket = socket_builder
             .namespace("/admin")
-            .tls_config(tls_connector)
+            .tls_config(tls_config())
             .opening_header("accept-encoding", "application/json")
             .on("test", |str, _| println!("Received: {:#?}", str))
             .on("message", |payload, _| println!("{:#?}", payload))

--- a/socketio/src/lib.rs
+++ b/socketio/src/lib.rs
@@ -199,6 +199,23 @@ pub use client::{ClientBuilder, RawClient, TransportType};
 #[deprecated(since = "0.3.0-alpha-2", note = "Socket renamed to Client")]
 pub use client::{ClientBuilder as SocketBuilder, RawClient as Socket};
 
+// Re-export TLS configurations. This is the same as the engine.io logic.
+// Needed here so it knows it's actually a re-import, not a new type.
+#[cfg(all(feature = "_native-tls", not(feature = "_rustls-tls")))]
+#[doc(hidden)]
+pub use native_tls::TlsConnector as TlsConfig;
+#[doc(hidden)]
+#[cfg(feature = "_rustls-tls")]
+pub use rustls::ClientConfig as TlsConfig;
+
+// Both native-tls and rustls is not supported at the same time
+#[cfg(not(feature = "_fallback-tls"))]
+#[cfg(all(feature = "_native-tls", feature = "_rustls-tls"))]
+compile_error!("Both native-tls and rustls features are enabled. Please enable only one of them.");
+
+#[cfg(not(any(feature = "_native-tls", feature = "_rustls-tls")))]
+compile_error!("No TLS feature is enabled. Please enable either native-tls or rustls.");
+
 #[cfg(test)]
 pub(crate) mod test {
     use url::Url;


### PR DESCRIPTION
Turned out to be rather easy due to all tls being handled by our dependencies.

Don't love the _fallback-tls feature, however with it we can use cargo-all-features, which helps reduce feature related bugs.

Downside of cargo-all-features is it takes a long time to execute.

Fixes: #407, #366

cc: @GaryCraft @tyilo @rageshkrishna