### PR TITLE
Add async/sync ack methods for responding to emitWithAck calls

### DIFF
--- a/socketio/src/asynchronous/client/client.rs
+++ b/socketio/src/asynchronous/client/client.rs
@@ -285,6 +285,52 @@ impl Client {
             .await
     }
 
+    /// When receive server's emitwithack callback event, invoke socket.ack(..) function can react to server with ack signal
+    /// use futures_util::FutureExt;
+    ///
+    /// # Example
+    /// ```
+    /// use futures_util::FutureExt;
+    /// use rust_socketio::{asynchronous::{ClientBuilder, Client}, Payload};
+    /// use serde_json::json;
+    /// use std::time::Duration;
+    /// use std::thread;
+    /// use bytes::Bytes;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///
+    ///     let callback = |payload: Payload, socket: Client| {
+    ///        async move {
+    ///           let byte_test = vec![0x01, 0x02];
+    ///           let _ = socket.ack(byte_test).await;
+    ///         }.boxed()
+    ///     };
+    ///
+    ///     // get a socket that is connected to the admin namespace
+    ///     let socket = ClientBuilder::new("http://localhost:4200")
+    ///         .namespace("/")
+    ///         .on("foo", callback)
+    ///         .on("error", |err, _| {
+    ///             async move { eprintln!("Error: {:#?}", err) }.boxed()
+    ///         })
+    ///         .connect()
+    ///         .await
+    ///         .expect("Connection failed");
+    ///     
+    ///
+    ///     thread::sleep(Duration::from_millis(30000));
+    ///     socket.disconnect().await.expect("Disconnect failed");
+    /// }
+    /// ```
+    #[inline]
+    pub async fn ack<D>(&self, data: D) -> Result<()>
+    where
+        D: Into<Payload>,
+    {
+        self.socket.read().await.ack(&self.nsp, data.into()).await
+    }
+
     /// Disconnects this client from the server by sending a `socket.io` closing
     /// packet.
     /// # Example

--- a/socketio/src/asynchronous/socket.rs
+++ b/socketio/src/asynchronous/socket.rs
@@ -14,7 +14,7 @@ use std::{
     fmt::Debug,
     pin::Pin,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicI32, Ordering},
         Arc,
     },
 };
@@ -24,16 +24,20 @@ pub(crate) struct Socket {
     engine_client: Arc<EngineClient>,
     connected: Arc<AtomicBool>,
     generator: StreamGenerator<Packet>,
+    ack_id: Arc<AtomicI32>,
 }
 
 impl Socket {
     /// Creates an instance of `Socket`.
     pub(super) fn new(engine_client: EngineClient) -> Result<Self> {
         let connected = Arc::new(AtomicBool::default());
+        let ack_id = Arc::new(AtomicI32::new(-1));
+
         Ok(Socket {
             engine_client: Arc::new(engine_client.clone()),
             connected: connected.clone(),
-            generator: StreamGenerator::new(Self::stream(engine_client, connected)),
+            ack_id: ack_id.clone(),
+            generator: StreamGenerator::new(Self::stream(engine_client, connected, ack_id)),
         })
     }
 
@@ -57,6 +61,9 @@ impl Socket {
         }
         if self.connected.load(Ordering::Acquire) {
             self.connected.store(false, Ordering::Release);
+        }
+        if self.ack_id.load(Ordering::Acquire) != -1 {
+            self.ack_id.store(-1, Ordering::Release);
         }
         Ok(())
     }
@@ -89,9 +96,17 @@ impl Socket {
         self.send(socket_packet).await
     }
 
+    /// Emits to connected other side with given data
+    pub async fn ack(&self, nsp: &str, data: Payload) -> Result<()> {
+        let socket_packet =
+            Packet::ack_from_payload(data, nsp, Some(self.ack_id.load(Ordering::Acquire)))?;
+        self.send(socket_packet).await
+    }
+
     fn stream(
         client: EngineClient,
         is_connected: Arc<AtomicBool>,
+        ack_id: Arc<AtomicI32>,
     ) -> Pin<Box<impl Stream<Item = Result<Packet>> + Send>> {
         Box::pin(try_stream! {
                 for await received_data in client.clone() {
@@ -101,6 +116,10 @@ impl Socket {
                         || packet.packet_id == EnginePacketId::MessageBinary
                     {
                         let packet = Self::handle_engineio_packet(packet, client.clone()).await?;
+
+                        if ack_id.load(Ordering::Acquire) != packet.id.unwrap_or(-1) {
+                            ack_id.store(packet.id.unwrap_or(-1), Ordering::Release);
+                        }
                         Self::handle_socketio_packet(&packet, is_connected.clone());
 
                         yield packet;

--- a/socketio/src/client/raw_client.rs
+++ b/socketio/src/client/raw_client.rs
@@ -82,6 +82,42 @@ impl RawClient {
         Ok(())
     }
 
+    /// Example code for handling ACK response when calling emitWithAck on the server
+    ///
+    /// # Example
+    /// ```
+    /// use rust_socketio::{ClientBuilder, Payload, RawClient};
+    /// use std::time::Duration;
+    /// use std::thread::sleep;
+    ///
+    ///
+    /// let ack_callback = |message: Payload, socket: RawClient| {
+    ///     match message {
+    ///         Payload::Text(values) => println!("{:#?}", values),
+    ///         Payload::Binary(bytes) => println!("Received bytes: {:#?}", bytes),
+    ///         // This is deprecated, use Payload::Text instead
+    ///         Payload::String(str) => println!("{}", str),
+    ///    }
+    ///    socket.ack("foo").unwrap();
+    /// };
+    ///
+    /// let mut socket = ClientBuilder::new("http://localhost:4200/")
+    ///     .on("foo", ack_callback)
+    ///     .connect()
+    ///     .expect("connection failed");
+    ///
+    ///
+    ///
+    /// sleep(Duration::from_secs(2));
+    /// ```
+    #[inline]
+    pub fn ack<D>(&self, data: D) -> Result<()>
+    where
+        D: Into<Payload>,
+    {
+        self.socket.ack(&self.nsp, data.into())
+    }
+
     /// Sends a message to the server using the underlying `engine.io` protocol.
     /// This message takes an event, which could either be one of the common
     /// events like "message" or "error" or a custom event like "foo". But be


### PR DESCRIPTION
I added asynchronous and synchronous ack functions to enable responses since there was no way to respond with ack when called via emitWithAck. Additionally, I introduced a separate ack_id variable for response handling.

```rust
 ///[sync/socket.rs]
pub(crate) struct Socket {
    //TODO: 0.4.0 refactor this
    engine_client: Arc<EngineClient>,
    connected: Arc<AtomicBool>,
    ack_id: Arc<AtomicI32>,
}
...
 pub fn ack(&self, nsp: &str, data: Payload) -> Result<()> {
        let socket_packet =
            Packet::ack_from_payload(data, nsp, Some(self.ack_id.load(Ordering::Acquire)))?;
        self.send(socket_packet)
}
...
...
 ///[async/socket.rs]
#[derive(Clone)]
pub(crate) struct Socket {
    engine_client: Arc<EngineClient>,
    connected: Arc<AtomicBool>,
    generator: StreamGenerator<Packet>,
    ack_id: Arc<AtomicI32>,
}
...
pub async fn ack(&self, nsp: &str, data: Payload) -> Result<()> {
    let socket_packet =
    Packet::ack_from_payload(data, nsp, Some(self.ack_id.load(Ordering::Acquire)))?;
    self.send(socket_packet).await
}

///[packet.rs]
pub(crate) fn ack_from_payload<'a>(
        payload: Payload,
        nsp: &'a str,
        ack_id: Option<i32>,
) ...{ ... }
```
The code below was tested on a Node.js Socket.IO server using emitWithAck

```rust
 ///sync use case
use rust_socketio::{ClientBuilder, Payload, RawClient};
use std::{thread::sleep, time::Duration};

fn main() {
    let callback = |payload: Payload, socket: RawClient| {
        match payload {
            #![allow(deprecated)]
            Payload::String(str) => println!("Received: {}", str),
            Payload::Binary(bin_data) => println!("Received bytes: {:#?}", bin_data),
            Payload::Text(vec) => println!("Received text: {:#?}", vec),
        }
        socket.ack("ack resend").expect("Server unreachable");
    };

    // get a socket that is connected to the admin namespace
    let socket = ClientBuilder::new("http://localhost:3000")
        //.namespace("/admin")
        .on("test", callback)
        .on("error", |err, _| eprintln!("Error: {:#?}", err))
        .connect()
        .expect("Connection failed");

    sleep(Duration::from_secs(5));
    println!("waiting...");
    socket.disconnect().expect("Disconnect failed");
    println!("disconnected waiting completed");
}
```

```rust
 ///async use case
use bytes::Bytes;
use futures_util::FutureExt;
use rust_socketio::{
    asynchronous::{Client, ClientBuilder},
    Payload,
};
use std::thread;
use std::time::Duration;

#[tokio::main]
async fn main() {
    let callback3 = |_payload: Payload, socket: Client| {
        async move {
            //Test React-to-Server communication (when the Socket.IO server invokes the emitWithAck method and expects a result)
            let buf: Bytes = Bytes::from_static(&[0x00, 0x01, 0x03]);
            //or socket.ack("string").await.expect("Ack invoke failed");
            socket.ack(buf).await.expect("Ack invoke failed");
        }
        .boxed()
    };

    let socket = ClientBuilder::new("http://localhost:3000")
        .namespace("/")
        .reconnect(false)
        .on("test", callback3)
        .on("error", |err, _| {
            async move { eprintln!("Error: {:#?}", err) }.boxed()
        })
        .connect()
        .await
        .expect("Connection Failed");

    thread::sleep(Duration::from_millis(25000));
    socket.disconnect().await.expect("Disconnect failed");
}
```

Fixes #491